### PR TITLE
Serialization code cleanups

### DIFF
--- a/src/serialize/value_list.rs
+++ b/src/serialize/value_list.rs
@@ -15,9 +15,11 @@ use scylla::serialize::writers::{RowWriter, WrittenCellProof};
 
 use crate::serialize::value::{PyAnyWrapper, PythonDriverSerializationError};
 
+#[derive(Default)]
 pub(crate) enum PyValueList {
     Sequence(Py<PySequence>),
     Mapping(Py<PyMapping>),
+    #[default]
     Empty,
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,17 +26,17 @@ impl Session {
         statement: ExecutableStatement,
         values: Option<PyValueList>,
     ) -> PyResult<RequestResult> {
+        // Why not accept PyValueList instead of Option<PyValueList>?
+        // It would require us to use `Default::default` as default value in
+        // `pyo3(signature = ...)`, and thus use `text_signature` as well
+        // to keep signature usable for Python users. I think it is cleaner
+        // to `unwrap_or_default()` here.
+        let values = values.unwrap_or_default();
         let result = self
             .session_spawn_on_runtime(async move |s| {
                 match statement {
-                    ExecutableStatement::Prepared(p) => match values {
-                        Some(row) => s.execute_unpaged(&p, row).await,
-                        None => s.execute_unpaged(&p, &[]).await,
-                    },
-                    ExecutableStatement::Unprepared(q) => match values {
-                        Some(row) => s.query_unpaged(q, row).await,
-                        None => s.query_unpaged(q, &[]).await,
-                    },
+                    ExecutableStatement::Prepared(p) => s.execute_unpaged(&p, values).await,
+                    ExecutableStatement::Unprepared(q) => s.query_unpaged(q, values).await,
                 }
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))
             })


### PR DESCRIPTION
This PR improves ergonomics of serialization code in various ways - see commit descriptions for more details.
It also solves one TODO: making the value list wrapper an enum, so that it can statically remember what type was passed by user, and avoid casting again in `SerializeRow` impl.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [ ] ~~I added relevant tests for new features and bug fixes.~~ - no new features or bug fixes, just refactors
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~ - no new public items
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~ - no changes in user-facing behavior or API
- [ ] ~~I added appropriate `Fixes:` annotations to PR description.~~ - we don't have an issue for that 
