### PR TITLE
Add Schema Agreement API to Session (await_schema_agreement, check_schema_agreement)

### DIFF
--- a/python/scylla/_rust/session.pyi
+++ b/python/scylla/_rust/session.pyi
@@ -107,3 +107,22 @@ class Session:
             If the schema agreement could not be reached.
         """
         ...
+
+    async def check_schema_agreement(self) -> uuid.UUID | None:
+        """
+        Check if all nodes in the cluster agree on the current schema version.
+
+        Unlike `await_schema_agreement`, this method does not wait for agreement to be reached,
+        but instead returns the current state immediately.
+
+        Returns
+        -------
+        uuid.UUID | None
+            The agreed schema version as a UUID object if all nodes agree, None otherwise.
+
+        Raises
+        ------
+        RuntimeError
+            If the schema agreement check failed.
+        """
+        ...

--- a/python/scylla/_rust/session.pyi
+++ b/python/scylla/_rust/session.pyi
@@ -1,4 +1,5 @@
 from typing import Any
+import uuid
 
 from .batch import Batch
 from .results import PagingState, RequestResult, RowFactory
@@ -85,5 +86,24 @@ class Session:
             In each returned row, columns other than `[applied]` contain either the current
             values of that row (if the condition was not met) or `None` values (if it was met).
 
+        """
+        ...
+
+    async def await_schema_agreement(self) -> uuid.UUID:
+        """
+        Wait until all nodes in the cluster agree on the current schema version.
+
+        This is useful after performing schema-altering operations to ensure that all nodes
+        have updated their schema before proceeding with operations that depend on the new schema.
+
+        Returns
+        -------
+        uuid.UUID
+            The agreed schema version as a UUID object.
+
+        Raises
+        ------
+        RuntimeError
+            If the schema agreement could not be reached.
         """
         ...

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -1,0 +1,37 @@
+import pytest
+import pytest_asyncio
+
+import uuid
+
+from scylla.session import Session
+from scylla.session_builder import SessionBuilder
+
+
+async def set_up() -> Session:
+    builder = SessionBuilder(["127.0.0.2"], 9042)
+    session = await builder.connect()
+
+    await session.execute("""
+            CREATE KEYSPACE IF NOT EXISTS testks
+            WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
+        """)
+
+    await session.execute("USE testks")
+
+    return session
+
+
+@pytest_asyncio.fixture(scope="module")
+async def session():
+    session = await set_up()
+    yield session
+    await session.execute("DROP KEYSPACE testks")
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_await_schema_agreement_returns_schema_version(session: Session):
+    schema_version = await session.await_schema_agreement()
+
+    assert isinstance(schema_version, uuid.UUID)
+    assert schema_version

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -30,6 +30,14 @@ async def session():
 
 @pytest.mark.asyncio
 @pytest.mark.requires_db
+async def test_check_schema_agreement_returns_schema_version_or_none(session: Session):
+    schema_version = await session.check_schema_agreement()
+
+    assert schema_version is None or isinstance(schema_version, uuid.UUID)
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
 async def test_await_schema_agreement_returns_schema_version(session: Session):
     schema_version = await session.await_schema_agreement()
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -90,6 +90,18 @@ impl Session {
 
         Ok(schema_version)
     }
+
+    async fn check_schema_agreement(&self) -> PyResult<Option<uuid::Uuid>> {
+        let schema_version = self
+            .session_spawn_on_runtime(async move |s| {
+                s.check_schema_agreement()
+                    .await
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            })
+            .await?;
+
+        Ok(schema_version)
+    }
 }
 
 impl Session {

--- a/src/session.rs
+++ b/src/session.rs
@@ -78,6 +78,18 @@ impl Session {
 
         Ok(RequestResult::new(result, Pager::unpaged(), factory))
     }
+
+    async fn await_schema_agreement(&self) -> PyResult<uuid::Uuid> {
+        let schema_version = self
+            .session_spawn_on_runtime(async move |s| {
+                s.await_schema_agreement()
+                    .await
+                    .map_err(|e| PyRuntimeError::new_err(e.to_string()))
+            })
+            .await?;
+
+        Ok(schema_version)
+    }
 }
 
 impl Session {


### PR DESCRIPTION
## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [X] I have split my patch into logically separate commits.
- [X] All commit messages clearly explain what they change and why.
- [X] I added relevant tests for new features and bug fixes.
- [X] All commits compile, pass static checks and pass test.
- [X] PR description sums up the changes and reasons why they should be introduced.
- [X] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [X] I added appropriate `Fixes:` annotations to PR description.

This PR adds Schema Agreement support to the Python driver Session API by exposing two async methods backed by the Rust driver:

`Session.await_schema_agreement()`-> `str`
`Session.check_schema_agreement()` -> `Optional[str]`

**Why:**

Schema operations often require waiting for agreement or polling it explicitly. Exposing these methods in the Python API aligns behavior with the underlying Rust driver and improves control for users writing schema management logic.

Fixes: #7 