### PR TITLE
Two-phase lazy cache with freeze semantics

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,6 +68,9 @@ jobs:
                   echo "Waiting for nodes... (attempt $i/30)" && sleep 1 ||
                   { echo "All nodes ready"; break; }; done
 
+            - name: Run native Rust tests
+              run: cargo test --no-default-features
+
             - name: Run tests with Python 3.10
               run: uv run --python 3.10 pytest -v
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,16 @@ name = "scylla"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = ["python-extension"]
+python-extension = ["pyo3/extension-module"]
+
 [lib]
 name = "scylla"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28.2", features = ["extension-module", "experimental-async", "bigdecimal", "num-bigint", "uuid", "chrono", "time", "py-clone"] }
+pyo3 = { version = "0.28.2", features = ["experimental-async", "bigdecimal", "num-bigint", "uuid", "chrono", "time", "py-clone"] }
 pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }
 tokio = { version = "1.42.0", features = ["full"] }
 scylla = { git = "https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver", features = ["chrono-04", "bigdecimal-04", "num-bigint-04"]}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,282 @@
+use std::{borrow::Borrow, collections::HashMap, hash::Hash, sync::RwLock};
+
+use pyo3::{
+    PyTypeInfo,
+    prelude::*,
+    sync::RwLockExt,
+    types::{PyDict, PyMappingProxy},
+};
+
+/// Internal cache state enum.
+///
+/// Represents state of the cache, either `Active` allowing for lazy population
+/// or `Frozen` with a frozen view of the cache.
+#[allow(unused)]
+enum CacheState<K, V> {
+    Active {
+        map: HashMap<K, Py<V>>,
+    },
+    Frozen {
+        map: HashMap<K, Py<V>>,
+        view: Py<PyMappingProxy>,
+    },
+}
+
+/// Two-phase cache with lazy population and immutable freeze boundary.
+///
+/// # Design overview
+///
+/// This cache has two distinct operational phases:
+///
+/// ## 1. Active phase
+/// - The cache behaves as a concurrent lazy-initialized map
+/// - Keys may be inserted on-demand via `get_or_init`
+/// - Missing values are computed using `f` closure
+/// - Computation is intentionally performed outside locks to reduce contention
+///
+/// ## 2. Frozen phase
+/// - The cache becomes immutable in terms of key domain
+/// - No new keys may be inserted
+/// - A stable Python `MappingProxy` view is created and returned
+/// - All subsequent reads observe a fixed snapshot of the cache
+///
+/// # Dual representation model
+///
+/// After freeze two synchronized representations are maintained:
+///
+/// - **Rust HashMap<K, Py<V>>**
+///   - Internal authoritative storage
+///   - Used for fast lookups and interop
+///
+/// - **Python MappingProxy**
+///   - Immutable external snapshot
+///   - Safe to expose across Python boundaries
+///
+/// # Concurrency model
+///
+/// - Uses `RwLock` for synchronization
+/// - Read path is lock-shared and fast
+/// - Write path re-validates state after lock acquisition
+/// - Computation is performed outside locks to reduce contention
+///
+/// # Consistency guarantees
+///
+/// - Active phase: eventual consistency under concurrency
+/// - Frozen phase: strict immutability of key domain
+/// - Freeze acts as a one-way semantic barrier
+///
+/// # Tradeoffs
+///
+/// - May perform redundant computation under race conditions
+/// - Intentionally favors throughput over avoiding duplicate work
+/// - Maintains duplicate storage for correctness across Rust/Python boundary
+#[allow(unused)]
+pub(crate) struct Cache<K, V> {
+    state: RwLock<CacheState<K, V>>,
+}
+
+impl<K, V> Default for Cache<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(unused)]
+impl<K, V> Cache<K, V> {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: RwLock::new(CacheState::Active {
+                map: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Retrieves a cached value or initializes it lazily if missing.
+    ///
+    /// # Behavior
+    ///
+    /// - If key exists (Active or Frozen): returns cached `Py<V>`
+    /// - If cache is Frozen and key is missing: returns `Ok(None)`
+    /// - If cache is Active and key is missing:
+    ///   - Calls `f` outside the lock
+    ///   - Re-checks state under write lock
+    ///   - Inserts value only if still absent and cache not frozen
+    ///
+    /// # Concurrency design
+    ///
+    /// This function uses an "optimistic compute" strategy:
+    ///
+    /// - Computation is intentionally done outside the lock
+    /// - This avoids blocking other threads during expensive initialization
+    /// - However, it may result in redundant computation if:
+    ///   - Another thread inserts the same key
+    ///   - The cache transitions to Frozen during computation
+    ///
+    /// In such cases, computed values are safely discarded.
+    ///
+    /// # Freeze interaction
+    ///
+    /// If the cache transitions to Frozen during execution:
+    /// - No new keys will be inserted
+    /// - This function will fall back to read-only behavior
+    /// - Computation may still occur but will not mutate state
+    ///
+    /// # Tradeoff
+    ///
+    /// This function favors throughput and low lock contention over
+    /// avoiding duplicate computation under race conditions.
+    pub(crate) fn get_or_init<'py, Q, F>(
+        &self,
+        py: Python<'py>,
+        key: &Q,
+        f: F,
+    ) -> PyResult<Option<Py<V>>>
+    where
+        K: Borrow<Q> + Eq + Hash,
+        Q: Hash + Eq + ?Sized + ToOwned<Owned = K>,
+        F: FnOnce(&Q) -> PyResult<Option<Py<V>>>,
+    {
+        {
+            let read_guard = self.state.read_py_attached(py).unwrap();
+            match &*read_guard {
+                CacheState::Active { map } | CacheState::Frozen { map, .. } => {
+                    if let Some(v) = map.get(key) {
+                        return Ok(Some(v.clone_ref(py)));
+                    }
+                }
+            }
+
+            if matches!(&*read_guard, CacheState::Frozen { .. }) {
+                return Ok(None);
+            }
+        }
+
+        // Avoid work inside write lock.
+        // Tradeoff wasted work for lock contention.
+        let Some(resolved) = f(key)? else {
+            return Ok(None);
+        };
+        let owned_key = key.to_owned();
+
+        let result = {
+            let mut write_guard = self.state.write_py_attached(py).unwrap();
+            match &mut *write_guard {
+                CacheState::Active { map } => {
+                    if let Some(existing) = map.get(key) {
+                        Some(existing.clone_ref(py))
+                    } else {
+                        map.insert(owned_key, resolved.clone_ref(py));
+                        Some(resolved)
+                    }
+                }
+                CacheState::Frozen { map, .. } => map.get(key).map(|v| v.clone_ref(py)),
+            }
+        };
+
+        Ok(result)
+    }
+
+    /// Freezes the cache (if not already frozen) and returns a Python immutable mapping view.
+    ///
+    /// # Behavior
+    ///
+    /// This function performs a one-time transition from Active to Frozen:
+    ///
+    /// - Calls `f` (allocating a Vec) for each freeze attempt; under contention it may be
+    ///   executed multiple times before one caller completes the transition to Frozen
+    /// - Inserts any missing entries from the successful freeze attempt into the internal cache
+    /// - Preserves already-existing values
+    /// - Constructs a Python `MappingProxy` view over the final cache state
+    /// - Returns the same frozen view on subsequent calls
+    ///
+    /// # Freeze semantics
+    ///
+    /// Once frozen:
+    /// - The key domain becomes immutable
+    /// - No new keys may be inserted via `get_or_init`
+    /// - All future reads reflect a stable snapshot of cache contents
+    ///
+    /// Freeze acts as a semantic barrier.
+    ///
+    /// # Consistency model
+    ///
+    /// This operation is intentionally not fully transactional:
+    ///
+    /// - If `f` returns an error, the operation aborts
+    /// - Only successful execution results in a frozen cache
+    ///
+    /// # Dual representation after freeze
+    ///
+    /// After completion, the cache stores:
+    ///
+    /// - Rust `HashMap<K, Py<V>>` for internal lookups
+    /// - Python `MappingProxy` as immutable external view
+    ///
+    /// This duplication is required because:
+    /// - Python requires an immutable mapping interface
+    /// - Rust requires retained ownership for access to single values.
+    ///
+    /// # Concurrency behavior
+    ///
+    /// - If already frozen, returns existing view immediately
+    /// - If active, performs full transition under write lock
+    ///
+    /// # Tradeoffs
+    ///
+    /// - May duplicate work during construction phase
+    /// - Builds full snapshot eagerly at freeze time
+    pub(crate) fn get_or_init_python_mapping<'py, F>(
+        &self,
+        py: Python<'py>,
+        f: F,
+    ) -> PyResult<Bound<'py, PyMappingProxy>>
+    where
+        K: IntoPyObject<'py> + Eq + Hash + Clone,
+        V: PyTypeInfo,
+        F: FnOnce() -> Vec<(K, PyResult<Py<V>>)>,
+    {
+        {
+            let read_guard = self.state.read_py_attached(py).unwrap();
+            if let CacheState::Frozen { view, .. } = &*read_guard {
+                return Ok(view.clone_ref(py).into_bound(py));
+            }
+        }
+
+        // Avoid work inside write lock.
+        // Tradeoff wasted work for lock contention.
+        let entries: Vec<(K, Py<V>)> = f()
+            .into_iter()
+            .map(|(k, v_res)| Ok((k, v_res?)))
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let mut write_guard = self.state.write_py_attached(py).unwrap();
+        match &mut *write_guard {
+            CacheState::Frozen { view, .. } => Ok(view.clone_ref(py).into_bound(py)),
+            CacheState::Active { map } => {
+                // This is relatively cheap to clone.
+                // Enables propagating error from dict inserts.
+                let mut frozen_map = map.clone();
+
+                for (k, v) in entries {
+                    frozen_map.entry(k).or_insert_with(|| v);
+                }
+                let dict = PyDict::new(py);
+                for (k, v) in frozen_map.iter() {
+                    dict.set_item(k.clone(), v.clone_ref(py))?;
+                }
+
+                let mapping = dict.as_mapping();
+                let view = PyMappingProxy::new(py, mapping).unbind();
+
+                let ret = view.clone_ref(py).into_bound(py);
+
+                *write_guard = CacheState::Frozen {
+                    map: frozen_map,
+                    view,
+                };
+
+                Ok(ret)
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 use std::sync::LazyLock;
 
+#[cfg(test)]
+mod tests;
+
 use crate::deserialize::value;
 use deserialize::results;
 use pyo3::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use pyo3::prelude::*;
 use tokio::runtime::Runtime;
 
 mod batch;
+mod cache;
 mod deserialize;
 mod enums;
 mod errors;

--- a/src/tests/cache_tests.rs
+++ b/src/tests/cache_tests.rs
@@ -1,0 +1,248 @@
+use pyo3::prelude::*;
+use pyo3::types::PyInt;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use crate::cache::Cache;
+
+#[test]
+fn get_or_init_inserts_and_reuses() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let key = "a".to_string();
+
+        let calls1 = calls.clone();
+        let v1 = cache
+            .get_or_init(py, &key, |_| {
+                calls1.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(42i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        let calls2 = calls.clone();
+        let v2 = cache
+            .get_or_init(py, &key, |_| {
+                calls2.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(999i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let ptr1 = v1.bind(py).as_ptr();
+        let ptr2 = v2.bind(py).as_ptr();
+        assert!(ptr1.eq(&ptr2));
+    });
+}
+
+#[test]
+fn get_or_init_none_does_not_insert() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+        let key = "missing".to_string();
+
+        let r = cache.get_or_init(py, &key, |_| Ok(None)).unwrap();
+        assert!(r.is_none());
+
+        let r2 = cache.get_or_init(py, &key, |_| Ok(None)).unwrap();
+        assert!(r2.is_none());
+    });
+}
+
+#[test]
+fn freeze_blocks_new_keys_and_exposes_mapping() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+
+        // Pre-populate one key in active mode.
+        let k1 = "x".to_string();
+        cache
+            .get_or_init(py, &k1, |_| Ok(Some(1i64.into_pyobject(py)?.unbind())))
+            .unwrap();
+
+        // Freeze with additional entries.
+        let proxy = cache
+            .get_or_init_python_mapping(py, || {
+                vec![
+                    (
+                        "x".to_string(),
+                        Ok(111i64.into_pyobject(py).unwrap().unbind()),
+                    ), // should not replace existing
+                    (
+                        "y".to_string(),
+                        Ok(2i64.into_pyobject(py).unwrap().unbind()),
+                    ),
+                ]
+            })
+            .unwrap();
+
+        let x: i64 = proxy.get_item("x").unwrap().extract().unwrap();
+        let y: i64 = proxy.get_item("y").unwrap().extract().unwrap();
+        assert_eq!(x, 1);
+        assert_eq!(y, 2);
+
+        // After freeze, no new keys via get_or_init.
+        let z = "z".to_string();
+        let r = cache
+            .get_or_init(py, &z, |_| Ok(Some(3i64.into_pyobject(py)?.unbind())))
+            .unwrap();
+        assert!(r.is_none());
+    });
+}
+
+#[test]
+fn freeze_is_idempotent_for_state() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+
+        let p1 = cache
+            .get_or_init_python_mapping(py, || {
+                vec![(
+                    "a".to_string(),
+                    Ok(10i64.into_pyobject(py).unwrap().unbind()),
+                )]
+            })
+            .unwrap();
+
+        let p2 = cache
+            .get_or_init_python_mapping(py, || {
+                vec![(
+                    "b".to_string(),
+                    Ok(20i64.into_pyobject(py).unwrap().unbind()),
+                )]
+            })
+            .unwrap();
+
+        let a1: i64 = p1.get_item("a").unwrap().extract().unwrap();
+        let a2: i64 = p2.get_item("a").unwrap().extract().unwrap();
+        assert_eq!(a1, 10);
+        assert_eq!(a2, 10);
+
+        // "b" should not appear because second freeze sees already frozen state.
+        assert!(p2.get_item("b").is_err());
+    });
+}
+
+#[test]
+fn get_or_init_does_not_run_initializer_when_key_already_present() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+        let key = "present".to_string();
+
+        cache
+            .get_or_init(py, &key, |_| Ok(Some(7i64.into_pyobject(py)?.unbind())))
+            .unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+
+        let value = cache
+            .get_or_init(py, &key, |_| {
+                calls2.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(999i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        let extracted: i64 = value.extract(py).unwrap();
+        assert_eq!(extracted, 7);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn get_or_init_does_not_run_initializer_when_cache_is_frozen_and_key_missing() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+
+        cache
+            .get_or_init_python_mapping(py, || {
+                vec![(
+                    "a".to_string(),
+                    Ok(1i64.into_pyobject(py).unwrap().unbind()),
+                )]
+            })
+            .unwrap();
+
+        let missing = "missing_after_freeze".to_string();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+
+        let result = cache
+            .get_or_init(py, &missing, |_| {
+                calls2.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(5i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap();
+
+        assert!(result.is_none());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    });
+}
+
+#[test]
+fn get_or_init_supports_borrowed_str_lookup_for_string_keys() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+
+        let v1 = cache
+            .get_or_init(py, "borrowed", |_| {
+                Ok(Some(11i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        let v2 = cache
+            .get_or_init(py, "borrowed", |_| {
+                Ok(Some(99i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        let i1: i64 = v1.extract(py).unwrap();
+        let i2: i64 = v2.extract(py).unwrap();
+        assert_eq!(i1, 11);
+        assert_eq!(i2, 11);
+    });
+}
+
+#[test]
+fn get_or_init_mixes_string_insert_and_str_lookup() {
+    Python::initialize();
+    Python::attach(|py| {
+        let cache = Cache::<String, PyInt>::new();
+        let owned = "mixed".to_string();
+
+        cache
+            .get_or_init(py, &owned, |_| Ok(Some(21i64.into_pyobject(py)?.unbind())))
+            .unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls2 = calls.clone();
+
+        let v = cache
+            .get_or_init(py, "mixed", |_| {
+                calls2.fetch_add(1, Ordering::SeqCst);
+                Ok(Some(1000i64.into_pyobject(py)?.unbind()))
+            })
+            .unwrap()
+            .unwrap();
+
+        let extracted: i64 = v.extract(py).unwrap();
+        assert_eq!(extracted, 21);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    });
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod cache_tests;


### PR DESCRIPTION
Adds a `Cache<K, V>` supporting lazy initialization and immutable snapshot freezing for exposing metadata.