### PR TITLE
Integrate Rust logging with Python logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "stable_deref_trait",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
  "yoke",
 ]
@@ -956,6 +957,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ chrono = "0.4"
 num-bigint = "0.4"
 async-trait = "0.1.89"
 log = "0.4.29"
+tracing = { version = "0.1", features = ["log"] }
 pyo3-log = "0.13.3"

--- a/examples/log.py
+++ b/examples/log.py
@@ -1,0 +1,37 @@
+import asyncio
+import logging
+
+from scylla.session_builder import SessionBuilder
+
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    # The logging level can be set using the standard levels:
+    #   CRITICAL (50), ERROR (40), WARNING (30), INFO (20), DEBUG (10)
+    #
+    # To enable very verbose "TRACE" messages (more detailed than DEBUG),
+    # set the level to 5:
+    #   logging.basicConfig(level=5, ...)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    print(logger.getEffectiveLevel())
+    print(logging.getLevelName(logger.getEffectiveLevel()))
+
+    host = "127.0.0.2"
+    port = 9042
+    logger.info(f"Connecting to {host}:{port}")
+
+    session = await SessionBuilder().contact_points([(host, port)]).connect()
+
+    await session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS example_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};"
+    )
+    await session.execute("USE example_ks;")
+
+
+asyncio.run(main())

--- a/python/tests/test_logging.py
+++ b/python/tests/test_logging.py
@@ -1,0 +1,26 @@
+import logging
+
+import pytest
+from _pytest.logging import LogCaptureFixture
+from scylla.session_builder import SessionBuilder
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_rust_logs_forwarded(caplog: LogCaptureFixture):
+    logging.basicConfig(level=logging.INFO)
+    caplog.set_level(logging.INFO)
+
+    session = await SessionBuilder().contact_points([("127.0.0.2", 9042)]).connect()
+
+    # Setting replication factor to 1 generates the following warning log:
+    # Response from the database contains a warning warning="Using
+    # Replication Factor replication_factor=1 lower than the
+    # minimum_replication_factor_warn_threshold=3 is not recommended."
+    await session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS example_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};"
+    )
+    await session.execute("USE example_ks;")
+
+    # Assert that the warning log was captured
+    assert any("Response from the database contains a warning" in rec.getMessage() for rec in caplog.records)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ mod tests;
 use crate::deserialize::value;
 use deserialize::results;
 use pyo3::prelude::*;
+use pyo3::sync::OnceExt;
+use std::sync::Once;
 use tokio::runtime::Runtime;
 
 mod batch;
@@ -26,11 +28,22 @@ use crate::utils::add_submodule;
 
 pub static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| Runtime::new().unwrap());
 
+static INIT_LOG: Once = Once::new();
+
+fn init_logging(py: Python<'_>) {
+    INIT_LOG.call_once_py_attached(py, || {
+        if let Err(e) = pyo3_log::try_init() {
+            eprintln!("pyo3_log::try_init failed: {:?}", e);
+        }
+    });
+}
+
 /// A Python module implemented in Rust.
 #[pymodule]
 #[pyo3(name = "_rust")]
 fn scylla(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
-    let _ = pyo3_log::try_init();
+    init_logging(py);
+
     add_submodule(
         py,
         module,


### PR DESCRIPTION
Fixes: #52 

## Description

Enabling `tracing` with the `log` feature causes trace instrumentation points to emit log records as well as trace events, if a default tracing subscriber has not been set. As a result, `pyo3-log` can capture these logs and forward them into Python’s standard logging system.

Logging verbosity can be controlled using standard Python logging levels: CRITICAL (50), ERROR (40), WARNING (30), INFO (20), DEBUG (10).

In addition, a more detailed TRACE level (more verbose than DEBUG) is supported by using level `5`:

```python
logging.basicConfig(level=5, ...)
```

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [ ] ~~I have provided docstrings for the public items that I want to introduce.~~
- [ ] ~~I have adjusted the documentation in `./docs/source/`.~~
- [x] I added appropriate `Fixes:` annotations to PR description.
