### PR TITLE
Session builder builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "scylla"
 version = "1.4.1"
-source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#71111dd07cd8f940f0e5ce1b35e8b098f2602ee2"
+source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#7756568aa3ef405614228e376ccfe7c0f05cb0d9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -761,7 +761,7 @@ dependencies = [
 [[package]]
 name = "scylla-cql"
 version = "1.4.0"
-source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#71111dd07cd8f940f0e5ce1b35e8b098f2602ee2"
+source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#7756568aa3ef405614228e376ccfe7c0f05cb0d9"
 dependencies = [
  "bigdecimal",
  "byteorder",
@@ -782,7 +782,7 @@ dependencies = [
 [[package]]
 name = "scylla-macros"
 version = "1.4.0"
-source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#71111dd07cd8f940f0e5ce1b35e8b098f2602ee2"
+source = "git+https://github.com/scylladb-zpp-2025-python-rs-driver/scylla-rust-driver#7756568aa3ef405614228e376ccfe7c0f05cb0d9"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/python/scylla/_rust/policies.pyi
+++ b/python/scylla/_rust/policies.pyi
@@ -133,15 +133,11 @@ class Peer:
     def rack(self) -> Optional[str]: ...
     def __repr__(self) -> str: ...
 
-class HostFilter:
+@runtime_checkable
+class HostFilter(Protocol):
     """
-    Base class for implementing custom host filtering.
-
-    Subclass this and override :meth:`accept` to decide whether a given
-    node should be considered by the driver.
+    Protocol for implementing custom host filtering.
     """
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def accept(self, peer: Peer) -> bool:
         """
         Decide whether the given peer should be accepted.
@@ -161,3 +157,17 @@ class HostFilter:
         accepting the host.
         """
         ...
+
+class AcceptAllHostFilter:
+    """
+    A host filter that accepts every node in the cluster.
+    """
+    def __init__(self) -> None: ...
+    def accept(self, peer: Peer) -> bool: ...
+
+class DcHostFilter:
+    """
+    A host filter that accepts nodes only from the specified datacenter.
+    """
+    def __init__(self, local_dc: str) -> None: ...
+    def accept(self, peer: Peer) -> bool: ...

--- a/python/scylla/_rust/policies.pyi
+++ b/python/scylla/_rust/policies.pyi
@@ -1,6 +1,7 @@
 import uuid
 from typing import Optional, Any, Protocol, runtime_checkable
 from ipaddress import IPv4Address, IPv6Address
+from datetime import timedelta
 
 class Authenticator:
     """
@@ -63,25 +64,57 @@ class AddressTranslator(Protocol):
         """
         ...
 
-class TimestampGenerator:
+@runtime_checkable
+class TimestampGenerator(Protocol):
     """
-    Base class for implementing custom client-side timestamp generation.
-
-    Subclass this and override :meth:`next_timestamp` to provide custom logic for generating timestamps for requests.
+    Protocol for custom client-side timestamp generation.
     """
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
     def next_timestamp(self) -> int:
         """
         Generate the next timestamp for a request.
 
         This method should return an integer representing the timestamp.
 
-        If this method is not overridden or raises an exception, the
+        If this method is not implemented or raises an exception, the
         driver will log the error and fallback to the current system timestamp.
 
         """
         ...
+
+class SimpleTimestampGenerator:
+    """
+    A simple client-side timestamp generator based on the system clock.
+
+    This generator returns the current system time in microseconds since
+    the Unix Epoch (1970-01-01)
+    """
+    def __init__(self) -> None: ...
+    def next_timestamp(self) -> int: ...
+
+class MonotonicTimestampGenerator:
+    """
+    Timestamp generator that guarantees monotonically increasing timestamps.
+
+    Parameters
+    ----------
+    warn_on_drift : bool, default True
+        Whether to log warnings when generated timestamps drift too far from
+        the system clock.
+
+    warning_threshold : float | timedelta, default 1
+        Drift threshold in seconds after which warnings may be emitted.
+
+    warning_interval : float | timedelta, default 1
+        Minimum interval in seconds between drift warnings.
+    """
+
+    def __init__(
+        self,
+        warn_on_drift: bool = True,
+        warning_threshold: float | timedelta = 1,
+        warning_interval: float | timedelta = 1,
+    ) -> None: ...
+    def next_timestamp(self) -> int: ...
 
 class Peer:
     """

--- a/python/scylla/_rust/policies.pyi
+++ b/python/scylla/_rust/policies.pyi
@@ -1,6 +1,5 @@
-import ipaddress
 import uuid
-from typing import Optional, Tuple, Any
+from typing import Optional, Any, Protocol, runtime_checkable
 from ipaddress import IPv4Address, IPv6Address
 
 class Authenticator:
@@ -42,23 +41,25 @@ class UntranslatedPeer:
     @property
     def host_id(self) -> uuid.UUID: ...
     @property
-    def untranslated_address(self) -> Tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int]: ...
+    def untranslated_address(self) -> tuple[IPv4Address | IPv6Address, int]: ...
     @property
     def datacenter(self) -> Optional[str]: ...
     @property
     def rack(self) -> Optional[str]: ...
     def __repr__(self) -> str: ...
 
-class AddressTranslator:
+@runtime_checkable
+class AddressTranslator(Protocol):
     """
-    Base class for implementing custom address translation.
-    Subclass this to provide your own translation logic.
+    Protocol for custom address translation.
     """
-    def __init__(self, *args: Any, **kwargs: Any) -> None: ...
-    def translate(self, info: UntranslatedPeer) -> Tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, int]:
+    def translate(self, info: UntranslatedPeer) -> str | tuple[str | IPv4Address | IPv6Address, int]:
         """
         Translates a node's address.
-        Must return a tuple of (ip_address, port_integer).
+        Must return a tuple of (ip_address | str, port_integer) or string with valid address and port.
+
+        When returning a string, it should therefore be a numeric IP address
+        plus port (for example ``"127.0.0.1:9042"`` or ``"[::1]:9042"``).
         """
         ...
 

--- a/python/scylla/_rust/session_builder.pyi
+++ b/python/scylla/_rust/session_builder.pyi
@@ -6,8 +6,12 @@ from ipaddress import IPv4Address, IPv6Address
 from .policies import AuthenticatorProvider, AddressTranslator, TimestampGenerator, HostFilter
 from .execution_profile import ExecutionProfile
 from .session import Session
+from datetime import timedelta
+from typing import Any
 
-ContactPoint = str | tuple[str | IPv4Address | IPv6Address, int]
+Address = str | tuple[str | IPv4Address | IPv6Address, int]
+
+TranslationMap = dict[Any, Any]
 
 class SessionBuilder:
     """
@@ -32,7 +36,7 @@ class SessionBuilder:
         """
         ...
 
-    def contact_points(self, contact_points: ContactPoint | Sequence[ContactPoint]) -> SessionBuilder:
+    def contact_points(self, contact_points: Address | Sequence[Address]) -> SessionBuilder:
         """
         Set the contact points used to bootstrap the connection.
 
@@ -111,14 +115,22 @@ class SessionBuilder:
         """
         ...
 
-    def address_translator(self, translator: AddressTranslator) -> SessionBuilder:
+    def address_translator(self, translator: AddressTranslator | TranslationMap) -> SessionBuilder:
         """
-        Registers a custom Python-defined address translator.
+        Registers an address translator for the session.
+
+        The translator can be either a custom Python object implementing the
+        :class:`AddressTranslator` protocol or a static translation mapping.
 
         Parameters
         ----------
-        translator : AddressTranslator
-            An instance of a class inheriting from :class:`AddressTranslator`.
+        translator : AddressTranslator | dict
+            The translation logic to apply. Can be:
+
+            Addresses in the dictionary can be provided as:
+
+            * A string: ``"127.0.0.1:9042"``
+            * A tuple: ``("127.0.0.1", 9042)``, ``(IPv4Address("127.0.0.1"), 9042)``, etc.
 
         Returns
         -------

--- a/python/scylla/_rust/session_builder.pyi
+++ b/python/scylla/_rust/session_builder.pyi
@@ -6,7 +6,6 @@ from ipaddress import IPv4Address, IPv6Address
 from .policies import AuthenticatorProvider, AddressTranslator, TimestampGenerator, HostFilter
 from .execution_profile import ExecutionProfile
 from .session import Session
-from datetime import timedelta
 from typing import Any
 
 Address = str | tuple[str | IPv4Address | IPv6Address, int]
@@ -149,7 +148,8 @@ class SessionBuilder:
         Parameters
         ----------
         generator : TimestampGenerator
-            An instance of a class inheriting from :class:`TimestampGenerator`.
+            A custom Python object implementing the :class:`TimestampGenerator`
+            protocol.
 
         Returns
         -------

--- a/python/scylla/_rust/session_builder.pyi
+++ b/python/scylla/_rust/session_builder.pyi
@@ -157,17 +157,23 @@ class SessionBuilder:
         """
         ...
 
-    def host_filter(self, host_filter: HostFilter) -> SessionBuilder:
+    def host_filter(self, host_filter: HostFilter | Sequence[Address]) -> SessionBuilder:
         """
-        Registers a custom Python-defined host filter.
+        Registers a host filter or a list of allowed addresses.
 
-        The filter is consulted to decide whether a discovered node should be
-        accepted by the driver.
+        This decides whether a discovered node should be accepted by the driver.
+        You can provide a custom filter object for complex logic, or a simple
+        sequence of addresses to act as an allow-list.
 
         Parameters
         ----------
-        host_filter : HostFilter
-            An instance of a class inheriting from :class:`HostFilter`.
+        host_filter : HostFilter | Sequence[Address]
+            If a object implements :class:`HostFilter` protocol, the driver calls
+            its ``accept`` method for each node.
+            If a sequence of addresses, only nodes matching those addresses
+            will be accepted.
+
+            Address = str | tuple[str | IPv4Address | IPv6Address, int]
 
         Returns
         -------

--- a/python/scylla/policies.py
+++ b/python/scylla/policies.py
@@ -1,12 +1,19 @@
+from typing import Protocol, runtime_checkable
+from ipaddress import IPv4Address, IPv6Address
+
 from ._rust.policies import (  # pyright: ignore[reportMissingModuleSource]
     Authenticator,
     AuthenticatorProvider,
-    AddressTranslator,
     UntranslatedPeer,
     TimestampGenerator,
     HostFilter,
     Peer,
 )
+
+
+@runtime_checkable
+class AddressTranslator(Protocol):
+    def translate(self, info: UntranslatedPeer) -> str | tuple[str | IPv4Address | IPv6Address, int]: ...
 
 __all__ = [
     "Authenticator",

--- a/python/scylla/policies.py
+++ b/python/scylla/policies.py
@@ -5,7 +5,8 @@ from ._rust.policies import (  # pyright: ignore[reportMissingModuleSource]
     Authenticator,
     AuthenticatorProvider,
     UntranslatedPeer,
-    TimestampGenerator,
+    MonotonicTimestampGenerator,
+    SimpleTimestampGenerator,
     HostFilter,
     Peer,
 )
@@ -15,12 +16,20 @@ from ._rust.policies import (  # pyright: ignore[reportMissingModuleSource]
 class AddressTranslator(Protocol):
     def translate(self, info: UntranslatedPeer) -> str | tuple[str | IPv4Address | IPv6Address, int]: ...
 
+
+@runtime_checkable
+class TimestampGenerator(Protocol):
+    def next_timestamp(self) -> int: ...
+
+
 __all__ = [
     "Authenticator",
     "AuthenticatorProvider",
     "AddressTranslator",
     "UntranslatedPeer",
-    "TimestampGenerator",
     "HostFilter",
+    "TimestampGenerator",
+    "MonotonicTimestampGenerator",
+    "SimpleTimestampGenerator",
     "Peer",
 ]

--- a/python/scylla/policies.py
+++ b/python/scylla/policies.py
@@ -7,7 +7,8 @@ from ._rust.policies import (  # pyright: ignore[reportMissingModuleSource]
     UntranslatedPeer,
     MonotonicTimestampGenerator,
     SimpleTimestampGenerator,
-    HostFilter,
+    AcceptAllHostFilter,
+    DcHostFilter,
     Peer,
 )
 
@@ -22,12 +23,19 @@ class TimestampGenerator(Protocol):
     def next_timestamp(self) -> int: ...
 
 
+@runtime_checkable
+class HostFilter(Protocol):
+    def accept(self, peer: Peer) -> bool: ...
+
+
 __all__ = [
     "Authenticator",
     "AuthenticatorProvider",
     "AddressTranslator",
     "UntranslatedPeer",
     "HostFilter",
+    "AcceptAllHostFilter",
+    "DcHostFilter",
     "TimestampGenerator",
     "MonotonicTimestampGenerator",
     "SimpleTimestampGenerator",

--- a/python/tests/test_session_builder.py
+++ b/python/tests/test_session_builder.py
@@ -56,9 +56,8 @@ async def test_contact_points_invalid_types(item: Any):
     with pytest.raises(SessionConfigError) as excinfo:
         builder.contact_points(item)  # type: ignore[arg-type]
 
-    assert (
-        "Invalid contact points type: expected str | tuple(str, int) | tuple(ipaddress, int) or a sequence of these"
-        in str(excinfo.value.__cause__)
+    assert "Invalid address type: expected str | tuple(str, int) | tuple(ipaddress, int) or a sequence of these" in str(
+        excinfo.value.__cause__
     )
 
 

--- a/python/tests/test_session_builder.py
+++ b/python/tests/test_session_builder.py
@@ -153,7 +153,7 @@ async def test_builtin_user_credentials(ccm_contact_points: list[tuple[str, int]
 Address = ipaddress.IPv4Address | ipaddress.IPv6Address
 
 
-class MockAddressTranslator(AddressTranslator):
+class MockAddressTranslator:
     default_ip: Address
     default_port: int
     call_log: list[UntranslatedPeer]
@@ -169,7 +169,7 @@ class MockAddressTranslator(AddressTranslator):
         return self.default_ip, self.default_port
 
 
-class FailingTranslator(AddressTranslator):
+class FailingTranslator:
     def translate(self, info: UntranslatedPeer) -> tuple[Address, int]:
         raise RuntimeError("Translation Exploded!")
 
@@ -178,6 +178,7 @@ class FailingTranslator(AddressTranslator):
 @pytest.mark.requires_db
 async def test_custom_address_translator_discovery():
     translator = MockAddressTranslator(ipaddress.IPv4Address("127.0.0.2"), 9042)
+    assert isinstance(translator, AddressTranslator)
 
     builder = (
         SessionBuilder()
@@ -202,6 +203,7 @@ async def test_custom_address_translator_discovery():
 @pytest.mark.xfail(reason="Currently, Python exceptions in the translator do not propagate to the driver")
 async def test_address_translator_failing_python_side():
     translator = FailingTranslator()
+    assert isinstance(translator, AddressTranslator)
 
     builder = (
         SessionBuilder()
@@ -214,6 +216,45 @@ async def test_address_translator_failing_python_side():
         await builder.connect()
 
     assert "Translation Exploded" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_address_translator_dict_discovery():
+    translator = {
+        (ipaddress.IPv4Address("127.0.0.2"), 9042): (ipaddress.IPv4Address("127.0.0.2"), 9042),
+        ("127.0.0.3", 9042): ("127.0.0.2", 9042),
+        ("127.0.0.4", 9042): ("127.0.0.2", 9042),
+    }
+
+    builder = (
+        SessionBuilder()
+        .contact_points([("127.0.0.2", 9042)])
+        .address_translator(translator)
+        .user("cassandra", "cassandra")
+    )
+
+    session = await builder.connect()
+
+    assert session is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_address_translator_dict_invalid():
+    translator = {
+        ("127.0.0.3.3", 9042): ("127.0.0.2.5", 9042),
+    }
+
+    with pytest.raises(SessionConfigError) as excinfo:
+        _ = (
+            SessionBuilder()
+            .contact_points([("127.0.0.2", 9042)])
+            .address_translator(translator)
+            .user("cassandra", "cassandra")
+        )
+
+    assert "invalid socket address syntax" in str(excinfo.value.__cause__)
 
 
 class MockTimestampGenerator(TimestampGenerator):

--- a/python/tests/test_session_builder.py
+++ b/python/tests/test_session_builder.py
@@ -11,9 +11,11 @@ from scylla.policies import (
     AuthenticatorProvider,
     AddressTranslator,
     UntranslatedPeer,
-    TimestampGenerator,
     HostFilter,
     Peer,
+    TimestampGenerator,
+    MonotonicTimestampGenerator,
+    SimpleTimestampGenerator,
 )
 
 from tests.helpers.ccm import (  # pyright: ignore[reportMissingTypeStubs]
@@ -22,6 +24,8 @@ from tests.helpers.ccm import (  # pyright: ignore[reportMissingTypeStubs]
     start_cluster,
     stop_and_remove_cluster,
 )
+
+import time
 
 
 @pytest.mark.asyncio
@@ -257,7 +261,7 @@ async def test_address_translator_dict_invalid():
     assert "invalid socket address syntax" in str(excinfo.value.__cause__)
 
 
-class MockTimestampGenerator(TimestampGenerator):
+class MockTimestampGenerator:
     fixed_ts: int
     called: bool
 
@@ -271,7 +275,7 @@ class MockTimestampGenerator(TimestampGenerator):
         return self.fixed_ts
 
 
-class FailingTimestampGenerator(TimestampGenerator):
+class FailingTimestampGenerator:
     def next_timestamp(self) -> int:
         raise RuntimeError("Timestamp Generation Exploded!")
 
@@ -281,6 +285,7 @@ class FailingTimestampGenerator(TimestampGenerator):
 async def test_custom_timestamp_generator_success() -> None:
     my_custom_ts = 1122334455
     ts_gen = MockTimestampGenerator(my_custom_ts)
+    assert isinstance(ts_gen, TimestampGenerator)
 
     builder = (
         SessionBuilder()
@@ -310,10 +315,45 @@ async def test_custom_timestamp_generator_success() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.requires_db
+async def test_simple_timestamp_generator_success() -> None:
+    ts_gen = SimpleTimestampGenerator()
+
+    builder = (
+        SessionBuilder()
+        .contact_points([("127.0.0.2", 9042)])
+        .user("cassandra", "cassandra")
+        .timestamp_generator(ts_gen)
+    )
+
+    session = await builder.connect()
+
+    await session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = "
+        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+    )
+    await session.execute("CREATE TABLE IF NOT EXISTS ks.verify_simple_ts (id int PRIMARY KEY, val text)")
+
+    now_micros = int(time.time() * 1_000_000)
+
+    await session.execute("INSERT INTO ks.verify_simple_ts (id, val) VALUES (1, 'rust-ts')")
+
+    result = await session.execute("SELECT WRITETIME(val) FROM ks.verify_simple_ts WHERE id = 1")
+    row = await result.first_row()
+
+    assert row is not None
+    db_timestamp = row["writetime(val)"]
+
+    assert db_timestamp >= now_micros
+    assert db_timestamp < now_micros + 5_000_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
 async def test_custom_timestamp_generator_fallback_on_failure(
     caplog: LogCaptureFixture,
 ) -> None:
     ts_gen = FailingTimestampGenerator()
+    assert isinstance(ts_gen, TimestampGenerator)
 
     builder = (
         SessionBuilder()
@@ -328,6 +368,32 @@ async def test_custom_timestamp_generator_fallback_on_failure(
 
     assert "Failed to generate custom timestamp from Python" in caplog.text
     assert "Timestamp Generation Exploded!" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_monotonic_timestamp_generator_works_with_session() -> None:
+    ts_gen = MonotonicTimestampGenerator()
+
+    builder = SessionBuilder().contact_points([("127.0.0.2", 9042)]).timestamp_generator(ts_gen)
+
+    session = await builder.connect()
+
+    await session.execute(
+        "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = "
+        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+    )
+    await session.execute("CREATE TABLE IF NOT EXISTS ks.verify_monotonic_ts (id int PRIMARY KEY, val text)")
+
+    await session.execute("INSERT INTO ks.verify_monotonic_ts (id, val) VALUES (1, 'a')")
+    await session.execute("UPDATE ks.verify_monotonic_ts SET val = 'b' WHERE id = 1")
+
+    result = await session.execute("SELECT WRITETIME(val) FROM ks.verify_monotonic_ts WHERE id = 1")
+    row = await result.first_row()
+
+    assert row is not None
+    assert isinstance(row["writetime(val)"], int)
+    assert row["writetime(val)"] > 0
 
 
 class AcceptAllHostFilter(HostFilter):

--- a/python/tests/test_session_builder.py
+++ b/python/tests/test_session_builder.py
@@ -11,11 +11,13 @@ from scylla.policies import (
     AuthenticatorProvider,
     AddressTranslator,
     UntranslatedPeer,
-    HostFilter,
     Peer,
     TimestampGenerator,
     MonotonicTimestampGenerator,
     SimpleTimestampGenerator,
+    AcceptAllHostFilter,
+    DcHostFilter,
+    HostFilter,
 )
 
 from tests.helpers.ccm import (  # pyright: ignore[reportMissingTypeStubs]
@@ -396,7 +398,7 @@ async def test_monotonic_timestamp_generator_works_with_session() -> None:
     assert row["writetime(val)"] > 0
 
 
-class AcceptAllHostFilter(HostFilter):
+class CustomAcceptAllHostFilter:
     def __init__(self) -> None:
         super().__init__()
         self.called = False
@@ -410,7 +412,7 @@ class AcceptAllHostFilter(HostFilter):
         return True
 
 
-class FailingHostFilter(HostFilter):
+class FailingHostFilter:
     def accept(self, peer: Peer) -> bool:
         raise RuntimeError("Host Filter Exploded!")
 
@@ -418,7 +420,8 @@ class FailingHostFilter(HostFilter):
 @pytest.mark.asyncio
 @pytest.mark.requires_db
 async def test_custom_host_filter_success() -> None:
-    host_filter = AcceptAllHostFilter()
+    host_filter = CustomAcceptAllHostFilter()
+    assert isinstance(host_filter, HostFilter)
 
     builder = (
         SessionBuilder().contact_points([("127.0.0.2", 9042)]).user("cassandra", "cassandra").host_filter(host_filter)
@@ -441,6 +444,7 @@ async def test_custom_host_filter_fallback_on_failure(
     caplog: LogCaptureFixture,
 ) -> None:
     host_filter = FailingHostFilter()
+    assert isinstance(host_filter, HostFilter)
 
     builder = (
         SessionBuilder().contact_points([("127.0.0.2", 9042)]).user("cassandra", "cassandra").host_filter(host_filter)
@@ -454,3 +458,59 @@ async def test_custom_host_filter_fallback_on_failure(
     assert row is not None
     assert "Failed to evaluate custom host filter from Python" in caplog.text
     assert "Host Filter Exploded!" in caplog.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_accept_all_host_filter() -> None:
+    host_filter = AcceptAllHostFilter()
+
+    builder = SessionBuilder().contact_points([("127.0.0.2", 9042)]).host_filter(host_filter)
+
+    session = await builder.connect()
+
+    result = await session.execute("SELECT release_version FROM system.local")
+    row = await result.first_row()
+
+    assert row is not None
+    assert len(row) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_dc_host_filter_matches() -> None:
+    host_filter = DcHostFilter("datacenter1")
+
+    builder = SessionBuilder().contact_points([("127.0.0.2", 9042)]).host_filter(host_filter)
+
+    session = await builder.connect()
+
+    result = await session.execute("SELECT data_center FROM system.local")
+    row = await result.first_row()
+
+    assert row is not None
+    assert row["data_center"] == "datacenter1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_host_filter_list_with_resolvable_dns() -> None:
+    accepted_list = ["127.0.0.1:9042", ("127.0.0.2", 9042), "localhost:9042"]
+
+    builder = SessionBuilder().contact_points([("127.0.0.2", 9042)]).host_filter(accepted_list)
+
+    session = await builder.connect()
+    assert session is not None
+
+    await session.execute("SELECT * FROM system.local")
+
+
+@pytest.mark.asyncio
+@pytest.mark.requires_db
+async def test_host_filter_list_with_garbage_string_fails() -> None:
+    garbage_list = ["this-is-not-an-address-and-has-no-port", ("127.0.0.1", 9042)]
+
+    with pytest.raises(SessionConfigError) as excinfo:
+        _ = SessionBuilder().contact_points([("127.0.0.2", 9042)]).host_filter(garbage_list)
+
+    assert "invalid socket address" in str(excinfo.value).lower()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -486,6 +486,10 @@ pub enum DriverSessionConfigError {
         type_name: String,
     },
 
+    InvalidTimestampGenerator {
+        type_name: String,
+    },
+
     InvalidContactPointAddress {
         addr: String,
         source: AddrParseError,
@@ -521,6 +525,12 @@ impl DriverSessionConfigError {
 
     pub fn invalid_address_translator(obj: Borrowed<PyAny>) -> Self {
         Self::InvalidAddressTranslator {
+            type_name: get_type_name(obj),
+        }
+    }
+
+    pub fn invalid_timestamp_generator(obj: Borrowed<PyAny>) -> Self {
+        Self::InvalidTimestampGenerator {
             type_name: get_type_name(obj),
         }
     }
@@ -590,6 +600,13 @@ impl From<DriverSessionConfigError> for PyErr {
             DriverSessionConfigError::InvalidAddressTranslator { type_name } => {
                 let message = format!(
                     "Expected an class implementing AddressTranslator protocol or a dict[ContactPoint, ContactPoint], got {type_name}"
+                );
+                build_session_config_pyerr(py, message, None, None)
+            }
+
+            DriverSessionConfigError::InvalidTimestampGenerator { type_name } => {
+                let message = format!(
+                    "Expected a class implementing TimestampGenerator protocol, got {type_name}"
                 );
                 build_session_config_pyerr(py, message, None, None)
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,12 @@
 // src/errors.rs
-use std::error::Error;
-use std::fmt;
-
 use pyo3::PyErr;
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyNone};
-
+use std::error::Error;
+use std::fmt;
+use std::net::AddrParseError;
 /* Python exception classes */
 
 create_exception!(errors, ScyllaError, PyException);
@@ -469,28 +468,36 @@ pub enum DriverSessionConfigError {
     ContactPointsIterationFailed {
         source: Box<PyErr>,
     },
-    /// The contact_points argument is of the wrong type.
+
     ContactPointTypeError {
         type_name: String,
     },
 
-    /// Wraps a Core Error with the index where it happened
     InvalidContactPointItem {
         index: usize,
         source: Box<PyErr>,
+    },
+
+    InvalidDuration {
+        type_name: String,
+    },
+
+    InvalidAddressTranslator {
+        type_name: String,
+    },
+
+    InvalidContactPointAddress {
+        addr: String,
+        source: AddrParseError,
     },
 }
 
 impl DriverSessionConfigError {
     /* Constructors */
     pub fn contact_point_type_error(obj: Borrowed<PyAny>) -> Self {
-        let type_name = obj
-            .get_type()
-            .name()
-            .map(|n| n.to_string())
-            .unwrap_or_else(|_| "UnknownType".to_string());
-
-        Self::ContactPointTypeError { type_name }
+        Self::ContactPointTypeError {
+            type_name: get_type_name(obj),
+        }
     }
 
     pub fn contact_points_iteration_failed(source: PyErr) -> Self {
@@ -504,6 +511,22 @@ impl DriverSessionConfigError {
             index,
             source: Box::new(source),
         }
+    }
+
+    pub fn invalid_duration(obj: Borrowed<PyAny>) -> Self {
+        Self::InvalidDuration {
+            type_name: get_type_name(obj),
+        }
+    }
+
+    pub fn invalid_address_translator(obj: Borrowed<PyAny>) -> Self {
+        Self::InvalidAddressTranslator {
+            type_name: get_type_name(obj),
+        }
+    }
+
+    pub fn invalid_contact_point_addr(addr: String, source: AddrParseError) -> Self {
+        Self::InvalidContactPointAddress { addr, source }
     }
 }
 
@@ -528,6 +551,13 @@ fn build_session_config_pyerr(
     err
 }
 
+fn get_type_name(obj: Borrowed<PyAny>) -> String {
+    obj.get_type()
+        .name()
+        .map(|n| n.to_string())
+        .unwrap_or_else(|_| "UnknownType".to_string())
+}
+
 impl From<DriverSessionConfigError> for PyErr {
     fn from(e: DriverSessionConfigError) -> PyErr {
         Python::attach(|py| match e {
@@ -548,6 +578,25 @@ impl From<DriverSessionConfigError> for PyErr {
             DriverSessionConfigError::InvalidContactPointItem { index, source } => {
                 let message = format!("Error processing contact point at index {index}");
                 build_session_config_pyerr(py, message, Some(*source), Some(index))
+            }
+
+            DriverSessionConfigError::InvalidDuration { type_name } => {
+                let message = format!(
+                    "Expected a datetime.timedelta or a non-negative finite float (seconds), got: {type_name}"
+                );
+                build_session_config_pyerr(py, message, None, None)
+            }
+
+            DriverSessionConfigError::InvalidAddressTranslator { type_name } => {
+                let message = format!(
+                    "Expected an class implementing AddressTranslator protocol or a dict[ContactPoint, ContactPoint], got {type_name}"
+                );
+                build_session_config_pyerr(py, message, None, None)
+            }
+
+            DriverSessionConfigError::InvalidContactPointAddress { addr, source } => {
+                let message = format!("Invalid contact point address '{addr}': {source}");
+                build_session_config_pyerr(py, message, None, None)
             }
         })
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,7 @@ use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyNone};
 use std::error::Error;
+use std::fmt;
 use std::net::AddrParseError;
 /* Python exception classes */
 
@@ -464,15 +465,15 @@ impl From<tokio::task::JoinError> for DriverSessionConnectionError {
 #[derive(Debug)]
 #[must_use]
 pub enum DriverSessionConfigError {
-    ContactPointsIterationFailed {
+    InvalidNodeAddressSequence {
         source: Box<PyErr>,
     },
 
-    ContactPointTypeError {
+    AddressTypeError {
         type_name: String,
     },
 
-    InvalidContactPointItem {
+    InvalidNodeAddressItem {
         index: usize,
         source: Box<PyErr>,
     },
@@ -495,7 +496,7 @@ pub enum DriverSessionConfigError {
 
     InvalidHostFilterAddress,
 
-    InvalidContactPointAddress {
+    InvalidNodeAddress {
         addr: String,
         source: AddrParseError,
     },
@@ -503,20 +504,20 @@ pub enum DriverSessionConfigError {
 
 impl DriverSessionConfigError {
     /* Constructors */
-    pub fn contact_point_type_error(obj: Borrowed<PyAny>) -> Self {
-        Self::ContactPointTypeError {
+    pub fn address_type_error(obj: Borrowed<PyAny>) -> Self {
+        Self::AddressTypeError {
             type_name: get_type_name(obj),
         }
     }
 
-    pub fn contact_points_iteration_failed(source: PyErr) -> Self {
-        Self::ContactPointsIterationFailed {
+    pub fn node_addr_iteration_failed(source: PyErr) -> Self {
+        Self::InvalidNodeAddressSequence {
             source: Box::new(source),
         }
     }
 
-    pub fn contact_points_invalid_item(index: usize, source: PyErr) -> Self {
-        Self::InvalidContactPointItem {
+    pub fn invalid_node_addr_item(index: usize, source: PyErr) -> Self {
+        Self::InvalidNodeAddressItem {
             index,
             source: Box::new(source),
         }
@@ -546,8 +547,8 @@ impl DriverSessionConfigError {
         }
     }
 
-    pub fn invalid_contact_point_addr(addr: String, source: AddrParseError) -> Self {
-        Self::InvalidContactPointAddress { addr, source }
+    pub fn invalid_node_addr(addr: String, source: AddrParseError) -> Self {
+        Self::InvalidNodeAddress { addr, source }
     }
 }
 
@@ -582,22 +583,24 @@ fn get_type_name(obj: Borrowed<PyAny>) -> String {
 impl From<DriverSessionConfigError> for PyErr {
     fn from(e: DriverSessionConfigError) -> PyErr {
         Python::attach(|py| match e {
-            DriverSessionConfigError::ContactPointTypeError { type_name } => {
+            DriverSessionConfigError::AddressTypeError { type_name } => {
                 let message = format!(
-                    "Invalid contact points type: expected str | tuple(str, int) | tuple(ipaddress, int) or a sequence of these, got {type_name}"
+                    "Invalid address type: expected str | tuple(str, int) | tuple(ipaddress, int) or a sequence of these, got {type_name}"
                 );
 
                 build_session_config_pyerr(py, message, None, None)
             }
 
-            DriverSessionConfigError::ContactPointsIterationFailed { source } => {
-                let message = "Failed to iterate over sequence of contact points".to_string();
+            DriverSessionConfigError::InvalidNodeAddressSequence { source } => {
+                let message =
+                    "Failed to iterate over sequence of addresses provided for configuration"
+                        .to_string();
 
                 build_session_config_pyerr(py, message, Some(*source), None)
             }
 
-            DriverSessionConfigError::InvalidContactPointItem { index, source } => {
-                let message = format!("Error processing contact point at index {index}");
+            DriverSessionConfigError::InvalidNodeAddressItem { index, source } => {
+                let message = format!("Error processing address at index {index}");
                 build_session_config_pyerr(py, message, Some(*source), Some(index))
             }
 
@@ -610,7 +613,7 @@ impl From<DriverSessionConfigError> for PyErr {
 
             DriverSessionConfigError::InvalidAddressTranslator { type_name } => {
                 let message = format!(
-                    "Expected an class implementing AddressTranslator protocol or a dict[ContactPoint, ContactPoint], got {type_name}"
+                    "Expected a class implementing AddressTranslator protocol or a dict[Address, Address], got {type_name}"
                 );
                 build_session_config_pyerr(py, message, None, None)
             }
@@ -629,8 +632,8 @@ impl From<DriverSessionConfigError> for PyErr {
                 build_session_config_pyerr(py, message, None, None)
             }
 
-            DriverSessionConfigError::InvalidContactPointAddress { addr, source } => {
-                let message = format!("Invalid contact point address '{addr}': {source}");
+            DriverSessionConfigError::InvalidNodeAddress { addr, source } => {
+                let message = format!("'{}' is not a valid address: {}", addr, source);
                 build_session_config_pyerr(py, message, None, None)
             }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,6 @@ use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyNone};
 use std::error::Error;
-use std::fmt;
 use std::net::AddrParseError;
 /* Python exception classes */
 
@@ -490,6 +489,12 @@ pub enum DriverSessionConfigError {
         type_name: String,
     },
 
+    InvalidHostFilter {
+        type_name: String,
+    },
+
+    InvalidHostFilterAddress,
+
     InvalidContactPointAddress {
         addr: String,
         source: AddrParseError,
@@ -531,6 +536,12 @@ impl DriverSessionConfigError {
 
     pub fn invalid_timestamp_generator(obj: Borrowed<PyAny>) -> Self {
         Self::InvalidTimestampGenerator {
+            type_name: get_type_name(obj),
+        }
+    }
+
+    pub fn invalid_host_filter(obj: Borrowed<PyAny>) -> Self {
+        Self::InvalidHostFilter {
             type_name: get_type_name(obj),
         }
     }
@@ -611,8 +622,20 @@ impl From<DriverSessionConfigError> for PyErr {
                 build_session_config_pyerr(py, message, None, None)
             }
 
+            DriverSessionConfigError::InvalidHostFilter { type_name } => {
+                let message = format!(
+                    "Expected a class implementing HostFilter protocol or a sequence[str | tuple[str | ipaddress, int]], got {type_name}"
+                );
+                build_session_config_pyerr(py, message, None, None)
+            }
+
             DriverSessionConfigError::InvalidContactPointAddress { addr, source } => {
                 let message = format!("Invalid contact point address '{addr}': {source}");
+                build_session_config_pyerr(py, message, None, None)
+            }
+
+            DriverSessionConfigError::InvalidHostFilterAddress => {
+                let message = "Invalid socket address".to_string();
                 build_session_config_pyerr(py, message, None, None)
             }
         })

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -482,6 +482,10 @@ pub enum DriverSessionConfigError {
         type_name: String,
     },
 
+    InvalidAuthenticatorProvider {
+        type_name: String,
+    },
+
     InvalidAddressTranslator {
         type_name: String,
     },
@@ -525,6 +529,12 @@ impl DriverSessionConfigError {
 
     pub fn invalid_duration(obj: Borrowed<PyAny>) -> Self {
         Self::InvalidDuration {
+            type_name: get_type_name(obj),
+        }
+    }
+
+    pub fn invalid_authenticator_provider(obj: Borrowed<PyAny>) -> Self {
+        Self::InvalidAuthenticatorProvider {
             type_name: get_type_name(obj),
         }
     }
@@ -608,6 +618,12 @@ impl From<DriverSessionConfigError> for PyErr {
                 let message = format!(
                     "Expected a datetime.timedelta or a non-negative finite float (seconds), got: {type_name}"
                 );
+                build_session_config_pyerr(py, message, None, None)
+            }
+
+            DriverSessionConfigError::InvalidAuthenticatorProvider { type_name } => {
+                let message =
+                    format!("Expected an AuthenticatorProvider subclass, got {type_name}");
                 build_session_config_pyerr(py, message, None, None)
             }
 

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,5 +1,5 @@
 use crate::errors::DriverSessionConfigError;
-use crate::session_builder::ContactPoint;
+use crate::session_builder::{ContactPoint, PyDuration};
 use async_trait::async_trait;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::{PyAnyMethods, PyDictMethods, PyModule, PyModuleMethods};
@@ -13,11 +13,13 @@ use scylla::cluster::metadata::Peer;
 use scylla::errors::{CustomTranslationError, TranslationError};
 use scylla::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 use scylla::policies::host_filter::HostFilter;
-use scylla::policies::timestamp_generator::TimestampGenerator;
+use scylla::policies::timestamp_generator::{
+    MonotonicTimestampGenerator, SimpleTimestampGenerator, TimestampGenerator,
+};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
 #[pyclass(subclass, skip_from_py_object, name = "AuthenticatorProvider")]
@@ -253,25 +255,8 @@ impl From<&UntranslatedPeer<'_>> for PyUntranslatedPeer {
     }
 }
 
-#[pyclass(subclass, skip_from_py_object, name = "TimestampGenerator")]
-pub(crate) struct PyTimestampGenerator {}
-
-#[pymethods]
-impl PyTimestampGenerator {
-    #[expect(unused_variables)]
-    #[new]
-    #[pyo3(signature = (*args, **kwargs))]
-    pub fn new(args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>) -> Self {
-        PyTimestampGenerator {}
-    }
-
-    fn next_timestamp(&self) -> PyResult<i64> {
-        Err(PyNotImplementedError::new_err("Method is not implemented"))
-    }
-}
-
-pub(crate) struct InternalTimestampGenerator {
-    pub(crate) py_timestamp_generator: Py<PyTimestampGenerator>,
+struct InternalTimestampGenerator {
+    py_timestamp_generator: Py<PyAny>,
 }
 impl TimestampGenerator for InternalTimestampGenerator {
     fn next_timestamp(&self) -> i64 {
@@ -279,7 +264,7 @@ impl TimestampGenerator for InternalTimestampGenerator {
             let py_generator = self.py_timestamp_generator.bind(py);
 
             py_generator
-                .call_method0("next_timestamp")
+                .call_method0(intern!(py, "next_timestamp"))
                 .and_then(|res| res.extract::<i64>())
                 .unwrap_or_else(|err| {
                     log::error!("Failed to generate custom timestamp from Python: {}", err);
@@ -291,6 +276,97 @@ impl TimestampGenerator for InternalTimestampGenerator {
                         .unwrap_or(0)
                 })
         })
+    }
+}
+
+pub(crate) struct TimestampGeneratorInput {
+    inner: Arc<dyn TimestampGenerator>,
+}
+
+impl TimestampGeneratorInput {
+    pub(crate) fn into_inner(self) -> Arc<dyn TimestampGenerator> {
+        self.inner
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for TimestampGeneratorInput {
+    type Error = DriverSessionConfigError;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(monotonic) = obj.cast::<PyMonotonicTimestampGenerator>() {
+            return Ok(Self {
+                inner: monotonic.get().inner.clone(),
+            });
+        }
+
+        if let Ok(simple) = obj.cast::<PySimpleTimestampGenerator>() {
+            return Ok(Self {
+                inner: simple.get().inner.clone(),
+            });
+        }
+
+        if !obj
+            .hasattr(intern!(obj.py(), "next_timestamp"))
+            .unwrap_or(false)
+        {
+            return Err(DriverSessionConfigError::invalid_timestamp_generator(obj));
+        }
+
+        Ok(Self {
+            inner: Arc::new(InternalTimestampGenerator {
+                py_timestamp_generator: obj.unbind(),
+            }),
+        })
+    }
+}
+
+#[pyclass(name = "MonotonicTimestampGenerator", frozen)]
+struct PyMonotonicTimestampGenerator {
+    inner: Arc<MonotonicTimestampGenerator>,
+}
+
+#[pymethods]
+impl PyMonotonicTimestampGenerator {
+    #[new]
+    #[pyo3(signature = (warn_on_drift=true, warning_threshold=PyDuration(Duration::from_secs(1)), warning_interval=PyDuration(Duration::from_secs(1))))]
+    pub fn new(
+        warn_on_drift: bool,
+        warning_threshold: PyDuration,
+        warning_interval: PyDuration,
+    ) -> Self {
+        let mut monotonic_timestamp_generator = MonotonicTimestampGenerator::new()
+            .with_warning_times(warning_threshold.0, warning_interval.0);
+
+        if !warn_on_drift {
+            monotonic_timestamp_generator = monotonic_timestamp_generator.without_warnings();
+        }
+
+        PyMonotonicTimestampGenerator {
+            inner: Arc::new(monotonic_timestamp_generator),
+        }
+    }
+
+    pub fn next_timestamp(&self) -> i64 {
+        self.inner.next_timestamp()
+    }
+}
+
+#[pyclass(name = "SimpleTimestampGenerator", frozen)]
+struct PySimpleTimestampGenerator {
+    inner: Arc<SimpleTimestampGenerator>,
+}
+
+#[pymethods]
+impl PySimpleTimestampGenerator {
+    #[new]
+    pub fn new() -> Self {
+        PySimpleTimestampGenerator {
+            inner: Arc::new(SimpleTimestampGenerator {}),
+        }
+    }
+
+    pub fn next_timestamp(&self) -> i64 {
+        self.inner.next_timestamp()
     }
 }
 
@@ -375,7 +451,8 @@ pub(crate) fn policies(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add_class::<PyAuthenticatorProvider>()?;
     module.add_class::<PyAuthenticator>()?;
     module.add_class::<PyUntranslatedPeer>()?;
-    module.add_class::<PyTimestampGenerator>()?;
+    module.add_class::<PyMonotonicTimestampGenerator>()?;
+    module.add_class::<PySimpleTimestampGenerator>()?;
     module.add_class::<PyHostFilter>()?;
     module.add_class::<PyPeer>()?;
     Ok(())

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -23,8 +23,7 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[derive(Clone)]
-#[pyclass(subclass, skip_from_py_object, name = "AuthenticatorProvider")]
+#[pyclass(subclass, skip_from_py_object, name = "AuthenticatorProvider", frozen)]
 pub(crate) struct PyAuthenticatorProvider {}
 
 #[pymethods]
@@ -41,9 +40,8 @@ impl PyAuthenticatorProvider {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct InternalAuthenticatorProvider {
-    pub(crate) python_authenticator: Py<PyAuthenticatorProvider>,
+struct InternalAuthenticatorProvider {
+    python_authenticator: Py<PyAuthenticatorProvider>,
 }
 
 #[async_trait]
@@ -56,13 +54,13 @@ impl AuthenticatorProvider for InternalAuthenticatorProvider {
             |py| -> PyResult<(Option<Vec<u8>>, Box<InternalAuthenticator>)> {
                 let py_auth_provider = self.python_authenticator.bind(py);
 
-                let py_auth_any =
-                    py_auth_provider.call_method1("new_authenticator", (authenticator_name,))?;
+                let py_auth_any = py_auth_provider
+                    .call_method1(intern!(py, "new_authenticator"), (authenticator_name,))?;
 
                 let py_auth = py_auth_any.cast::<PyAuthenticator>()?;
 
                 let response = py_auth
-                    .call_method0("initial_response")?
+                    .call_method0(intern!(py, "initial_response"))?
                     .extract::<Option<Vec<u8>>>()?;
 
                 Ok((
@@ -79,7 +77,7 @@ impl AuthenticatorProvider for InternalAuthenticatorProvider {
     }
 }
 
-#[pyclass(subclass, name = "Authenticator")]
+#[pyclass(subclass, name = "Authenticator", frozen)]
 pub(crate) struct PyAuthenticator {}
 
 #[pymethods]
@@ -104,8 +102,8 @@ impl PyAuthenticator {
     }
 }
 
-pub(crate) struct InternalAuthenticator {
-    pub(crate) python_authenticator: Py<PyAuthenticator>,
+struct InternalAuthenticator {
+    python_authenticator: Py<PyAuthenticator>,
 }
 
 #[async_trait]
@@ -118,7 +116,7 @@ impl AuthenticatorSession for InternalAuthenticator {
             let py_auth = self.python_authenticator.bind(py);
 
             py_auth
-                .call_method1("evaluate_challenge", (token,))?
+                .call_method1(intern!(py, "evaluate_challenge"), (token,))?
                 .extract::<Option<Vec<u8>>>()
         })
         .map_err(|e| format!("Python evaluate_challenge failed: {:?}", e))?;
@@ -130,13 +128,41 @@ impl AuthenticatorSession for InternalAuthenticator {
         let result = Python::attach(|py| -> PyResult<()> {
             let py_auth = self.python_authenticator.bind(py);
 
-            py_auth.call_method1("success", (token,))?;
+            py_auth.call_method1(intern!(py, "success"), (token,))?;
 
             Ok(())
         })
         .map_err(|e| format!("Python success failed: {:?}", e))?;
 
         Ok(result)
+    }
+}
+
+pub(crate) struct AuthenticatorProviderInput {
+    inner: Arc<dyn AuthenticatorProvider>,
+}
+
+impl AuthenticatorProviderInput {
+    pub(crate) fn into_inner(self) -> Arc<dyn AuthenticatorProvider> {
+        self.inner
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for AuthenticatorProviderInput {
+    type Error = DriverSessionConfigError;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(python_authenticator) = obj.extract::<Py<PyAuthenticatorProvider>>() {
+            return Ok(Self {
+                inner: Arc::new(InternalAuthenticatorProvider {
+                    python_authenticator,
+                }),
+            });
+        }
+
+        Err(DriverSessionConfigError::invalid_authenticator_provider(
+            obj,
+        ))
     }
 }
 

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,5 +1,5 @@
 use crate::errors::DriverSessionConfigError;
-use crate::session_builder::{ContactPoint, ContactPoints, PyDuration};
+use crate::session_builder::{NodeAddr, NodeAddrs, PyDuration};
 use async_trait::async_trait;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::{PyAnyMethods, PyDictMethods, PyModule, PyModuleMethods};
@@ -156,7 +156,7 @@ impl AddressTranslator for InternalAddressTranslator {
 
             let translated = py_trans
                 .call_method1(intern!(py, "translate"), (peer_info,))?
-                .extract::<ContactPoint>()?;
+                .extract::<NodeAddr>()?;
 
             SocketAddr::try_from(translated).map_err(|e| e.into())
         })
@@ -184,17 +184,17 @@ impl<'py> FromPyObject<'_, 'py> for AddressTranslatorInput {
                 .enumerate()
                 .map(|(idx, (k, v))| {
                     let from = k
-                        .extract::<ContactPoint>()
+                        .extract::<NodeAddr>()
                         .and_then(SocketAddr::try_from)
                         .map_err(|e| {
-                            DriverSessionConfigError::contact_points_invalid_item(idx, e.into())
+                            DriverSessionConfigError::invalid_node_addr_item(idx, e.into())
                         })?;
 
                     let to = v
-                        .extract::<ContactPoint>()
+                        .extract::<NodeAddr>()
                         .and_then(SocketAddr::try_from)
                         .map_err(|e| {
-                            DriverSessionConfigError::contact_points_invalid_item(idx, e.into())
+                            DriverSessionConfigError::invalid_node_addr_item(idx, e.into())
                         })?;
 
                     Ok((from, to))
@@ -406,8 +406,8 @@ impl<'py> FromPyObject<'_, 'py> for HostFilterInput {
     type Error = DriverSessionConfigError;
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-        if let Ok(points) = obj.extract::<ContactPoints>() {
-            let filter = AllowListHostFilter::new(points)
+        if let Ok(points) = obj.extract::<NodeAddrs>() {
+            let filter = AllowListHostFilter::new(points.inner)
                 .map_err(|_| DriverSessionConfigError::InvalidHostFilterAddress)?;
             return Ok(Self {
                 inner: Arc::new(filter),

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,5 +1,5 @@
 use crate::errors::DriverSessionConfigError;
-use crate::session_builder::{ContactPoint, PyDuration};
+use crate::session_builder::{ContactPoint, ContactPoints, PyDuration};
 use async_trait::async_trait;
 use pyo3::exceptions::PyNotImplementedError;
 use pyo3::prelude::{PyAnyMethods, PyDictMethods, PyModule, PyModuleMethods};
@@ -12,7 +12,9 @@ use scylla::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSess
 use scylla::cluster::metadata::Peer;
 use scylla::errors::{CustomTranslationError, TranslationError};
 use scylla::policies::address_translator::{AddressTranslator, UntranslatedPeer};
-use scylla::policies::host_filter::HostFilter;
+use scylla::policies::host_filter::{
+    AcceptAllHostFilter, AllowListHostFilter, DcHostFilter, HostFilter,
+};
 use scylla::policies::timestamp_generator::{
     MonotonicTimestampGenerator, SimpleTimestampGenerator, TimestampGenerator,
 };
@@ -370,34 +372,17 @@ impl PySimpleTimestampGenerator {
     }
 }
 
-#[pyclass(subclass, skip_from_py_object, name = "HostFilter")]
-pub(crate) struct PyHostFilter {}
-
-#[pymethods]
-impl PyHostFilter {
-    #[expect(unused_variables)]
-    #[new]
-    #[pyo3(signature = (*args, **kwargs))]
-    pub fn new(args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>) -> Self {
-        PyHostFilter {}
-    }
-
-    fn accept(&self, _peer: Py<PyPeer>) -> PyResult<bool> {
-        Err(PyNotImplementedError::new_err("Method is not implemented"))
-    }
-}
-
-pub(crate) struct InternalHostFilter {
-    pub(crate) py_host_filter: Py<PyHostFilter>,
+struct InternalHostFilter {
+    py_host_filter: Py<PyAny>,
 }
 impl HostFilter for InternalHostFilter {
     fn accept(&self, peer: &Peer) -> bool {
         Python::attach(|py| {
             let py_filter = self.py_host_filter.bind(py);
-            let py_peer = PyPeer::from(peer);
+            let py_peer = PyPeer::from(peer.clone());
 
             py_filter
-                .call_method1("accept", (py_peer,))
+                .call_method1(intern!(py, "accept"), (py_peer,))
                 .and_then(|res| res.extract::<bool>())
                 .unwrap_or_else(|err| {
                     log::error!("Failed to evaluate custom host filter from Python: {}", err);
@@ -407,13 +392,103 @@ impl HostFilter for InternalHostFilter {
     }
 }
 
-#[pyclass(get_all, frozen, name = "Peer")]
+pub(crate) struct HostFilterInput {
+    inner: Arc<dyn HostFilter>,
+}
+
+impl HostFilterInput {
+    pub(crate) fn into_inner(self) -> Arc<dyn HostFilter> {
+        self.inner
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for HostFilterInput {
+    type Error = DriverSessionConfigError;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(points) = obj.extract::<ContactPoints>() {
+            let filter = AllowListHostFilter::new(points)
+                .map_err(|_| DriverSessionConfigError::InvalidHostFilterAddress)?;
+            return Ok(Self {
+                inner: Arc::new(filter),
+            });
+        }
+
+        if let Ok(filter) = obj.cast::<PyAcceptAllHostFilter>() {
+            return Ok(Self {
+                inner: filter.get().inner.clone(),
+            });
+        }
+
+        if let Ok(filter) = obj.cast::<PyDcHostFilter>() {
+            return Ok(Self {
+                inner: filter.get().inner.clone(),
+            });
+        }
+
+        if !obj.hasattr(intern!(obj.py(), "accept")).unwrap_or(false) {
+            return Err(DriverSessionConfigError::invalid_host_filter(obj));
+        }
+
+        Ok(Self {
+            inner: Arc::new(InternalHostFilter {
+                py_host_filter: obj.to_owned().unbind(),
+            }),
+        })
+    }
+}
+
+#[pyclass(name = "AcceptAllHostFilter", frozen)]
+struct PyAcceptAllHostFilter {
+    inner: Arc<AcceptAllHostFilter>,
+}
+
+#[pymethods]
+impl PyAcceptAllHostFilter {
+    #[new]
+    pub fn new() -> Self {
+        PyAcceptAllHostFilter {
+            inner: Arc::new(AcceptAllHostFilter {}),
+        }
+    }
+
+    pub fn accept(&self, _peer: Py<PyPeer>) -> bool {
+        true
+    }
+}
+
+#[pyclass(name = "DcHostFilter", frozen)]
+struct PyDcHostFilter {
+    inner: Arc<DcHostFilter>,
+}
+
+#[pymethods]
+impl PyDcHostFilter {
+    #[new]
+    pub fn new(local_dc: String) -> Self {
+        PyDcHostFilter {
+            inner: Arc::new(DcHostFilter::new(local_dc)),
+        }
+    }
+
+    pub fn accept(&self, peer: Py<PyPeer>) -> bool {
+        self.inner.accept(&peer.get().inner)
+    }
+}
+
+#[pyclass(frozen, name = "Peer")]
 pub struct PyPeer {
+    inner: Peer,
+    #[pyo3(get)]
     pub host_id: uuid::Uuid,
+    #[pyo3(get)]
     pub address: (IpAddr, u16),
     //TODO when LBC is merged switch to using Token instead of i64
+    #[pyo3(get)]
     pub tokens: Vec<i64>,
+    #[pyo3(get)]
     pub datacenter: Option<String>,
+    #[pyo3(get)]
     pub rack: Option<String>,
 }
 
@@ -434,14 +509,15 @@ impl PyPeer {
     }
 }
 
-impl From<&Peer> for PyPeer {
-    fn from(peer: &Peer) -> Self {
+impl From<Peer> for PyPeer {
+    fn from(peer: Peer) -> Self {
         Self {
             host_id: peer.host_id,
             address: (peer.address.ip(), peer.address.port()),
             tokens: peer.tokens.iter().map(|t| t.value()).collect(),
             datacenter: peer.datacenter.clone(),
             rack: peer.rack.clone(),
+            inner: peer,
         }
     }
 }
@@ -453,7 +529,8 @@ pub(crate) fn policies(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add_class::<PyUntranslatedPeer>()?;
     module.add_class::<PyMonotonicTimestampGenerator>()?;
     module.add_class::<PySimpleTimestampGenerator>()?;
-    module.add_class::<PyHostFilter>()?;
+    module.add_class::<PyAcceptAllHostFilter>()?;
+    module.add_class::<PyDcHostFilter>()?;
     module.add_class::<PyPeer>()?;
     Ok(())
 }

--- a/src/policies.rs
+++ b/src/policies.rs
@@ -1,15 +1,22 @@
+use crate::errors::DriverSessionConfigError;
+use crate::session_builder::ContactPoint;
 use async_trait::async_trait;
 use pyo3::exceptions::PyNotImplementedError;
-use pyo3::prelude::{PyAnyMethods, PyModule, PyModuleMethods};
+use pyo3::prelude::{PyAnyMethods, PyDictMethods, PyModule, PyModuleMethods};
 use pyo3::types::{PyDict, PyString, PyTuple};
-use pyo3::{Bound, Py, PyResult, Python, pyclass, pymethods, pymodule};
+use pyo3::{
+    Borrowed, Bound, BoundObject, FromPyObject, Py, PyAny, PyResult, Python, intern, pyclass,
+    pymethods, pymodule,
+};
 use scylla::authentication::{AuthError, AuthenticatorProvider, AuthenticatorSession};
 use scylla::cluster::metadata::Peer;
 use scylla::errors::{CustomTranslationError, TranslationError};
 use scylla::policies::address_translator::{AddressTranslator, UntranslatedPeer};
 use scylla::policies::host_filter::HostFilter;
 use scylla::policies::timestamp_generator::TimestampGenerator;
+use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone)]
@@ -129,25 +136,8 @@ impl AuthenticatorSession for InternalAuthenticator {
     }
 }
 
-#[pyclass(subclass, skip_from_py_object, name = "AddressTranslator")]
-pub(crate) struct PyAddressTranslator {}
-
-#[pymethods]
-impl PyAddressTranslator {
-    #[expect(unused_variables)]
-    #[new]
-    #[pyo3(signature = (*args, **kwargs))]
-    pub fn new(args: &Bound<'_, PyTuple>, kwargs: Option<&Bound<'_, PyDict>>) -> Self {
-        PyAddressTranslator {}
-    }
-
-    fn translate(&self, _addr: Py<PyUntranslatedPeer>) -> PyResult<(IpAddr, u16)> {
-        Err(PyNotImplementedError::new_err("Method is not implemented"))
-    }
-}
-
-pub(crate) struct InternalAddressTranslator {
-    pub(crate) python_translator: Py<PyAddressTranslator>,
+struct InternalAddressTranslator {
+    inner: Py<PyAny>,
 }
 
 #[async_trait]
@@ -156,17 +146,71 @@ impl AddressTranslator for InternalAddressTranslator {
         &self,
         untranslated_peer: &UntranslatedPeer,
     ) -> Result<SocketAddr, TranslationError> {
-        let result = Python::attach(|py| -> PyResult<(IpAddr, u16)> {
-            let py_trans = self.python_translator.bind(py);
-            let py_peer_info = PyUntranslatedPeer::from(untranslated_peer);
+        Python::attach(|py| -> PyResult<SocketAddr> {
+            let py_trans = self.inner.bind(py);
+            let peer_info = PyUntranslatedPeer::from(untranslated_peer);
 
-            py_trans
-                .call_method1("translate", (py_peer_info,))?
-                .extract::<(IpAddr, u16)>()
+            let translated = py_trans
+                .call_method1(intern!(py, "translate"), (peer_info,))?
+                .extract::<ContactPoint>()?;
+
+            SocketAddr::try_from(translated).map_err(|e| e.into())
         })
-        .map_err(CustomTranslationError::new)?;
+        .map_err(|e| CustomTranslationError::new(e).into())
+    }
+}
 
-        Ok(SocketAddr::from(result))
+pub(crate) struct AddressTranslatorInput {
+    inner: Arc<dyn AddressTranslator>,
+}
+
+impl AddressTranslatorInput {
+    pub(crate) fn into_inner(self) -> Arc<dyn AddressTranslator> {
+        self.inner
+    }
+}
+
+impl<'py> FromPyObject<'_, 'py> for AddressTranslatorInput {
+    type Error = DriverSessionConfigError;
+
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(dict) = obj.cast::<PyDict>() {
+            let map = dict
+                .iter()
+                .enumerate()
+                .map(|(idx, (k, v))| {
+                    let from = k
+                        .extract::<ContactPoint>()
+                        .and_then(SocketAddr::try_from)
+                        .map_err(|e| {
+                            DriverSessionConfigError::contact_points_invalid_item(idx, e.into())
+                        })?;
+
+                    let to = v
+                        .extract::<ContactPoint>()
+                        .and_then(SocketAddr::try_from)
+                        .map_err(|e| {
+                            DriverSessionConfigError::contact_points_invalid_item(idx, e.into())
+                        })?;
+
+                    Ok((from, to))
+                })
+                .collect::<Result<HashMap<SocketAddr, SocketAddr>, Self::Error>>()?;
+
+            return Ok(Self {
+                inner: Arc::new(map),
+            });
+        }
+
+        if !obj.hasattr(intern!(obj.py(), "translate")).unwrap_or(false) {
+            return Err(DriverSessionConfigError::invalid_address_translator(obj));
+        }
+
+        Ok(Self {
+            inner: Arc::new(InternalAddressTranslator {
+                inner: obj.unbind(),
+            }),
+        })
     }
 }
 
@@ -331,7 +375,6 @@ pub(crate) fn policies(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResul
     module.add_class::<PyAuthenticatorProvider>()?;
     module.add_class::<PyAuthenticator>()?;
     module.add_class::<PyUntranslatedPeer>()?;
-    module.add_class::<PyAddressTranslator>()?;
     module.add_class::<PyTimestampGenerator>()?;
     module.add_class::<PyHostFilter>()?;
     module.add_class::<PyPeer>()?;

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -2,8 +2,7 @@ use crate::RUNTIME;
 use crate::errors::{DriverSessionConfigError, DriverSessionConnectionError};
 use crate::execution_profile::ExecutionProfile;
 use crate::policies::{
-    AddressTranslatorInput, HostFilterInput, InternalAuthenticatorProvider,
-    PyAuthenticatorProvider, TimestampGeneratorInput,
+    AddressTranslatorInput, AuthenticatorProviderInput, HostFilterInput, TimestampGeneratorInput,
 };
 use crate::session::Session;
 use pyo3::prelude::*;
@@ -55,11 +54,9 @@ impl SessionBuilder {
 
     fn authenticator_provider<'py>(
         mut slf: PyRefMut<'py, Self>,
-        authenticator: Py<PyAuthenticatorProvider>,
+        authenticator: AuthenticatorProviderInput,
     ) -> PyRefMut<'py, Self> {
-        slf.config.authenticator = Some(Arc::new(InternalAuthenticatorProvider {
-            python_authenticator: authenticator,
-        }));
+        slf.config.authenticator = Some(authenticator.into_inner());
 
         slf
     }

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -3,7 +3,7 @@ use crate::errors::{DriverSessionConfigError, DriverSessionConnectionError};
 use crate::execution_profile::ExecutionProfile;
 use crate::policies::{
     AddressTranslatorInput, InternalAuthenticatorProvider, InternalHostFilter,
-    InternalTimestampGenerator, PyAuthenticatorProvider, PyHostFilter, PyTimestampGenerator,
+    PyAuthenticatorProvider, PyHostFilter, TimestampGeneratorInput,
 };
 use crate::session::Session;
 use pyo3::prelude::*;
@@ -13,6 +13,7 @@ use scylla::client::session::SessionConfig;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 #[pyclass]
 struct SessionBuilder {
@@ -74,11 +75,9 @@ impl SessionBuilder {
 
     fn timestamp_generator<'py>(
         mut slf: PyRefMut<'py, Self>,
-        generator: Py<PyTimestampGenerator>,
+        generator: TimestampGeneratorInput,
     ) -> PyRefMut<'py, Self> {
-        slf.config.timestamp_generator = Some(Arc::new(InternalTimestampGenerator {
-            py_timestamp_generator: generator,
-        }));
+        slf.config.timestamp_generator = Some(generator.into_inner());
 
         slf
     }
@@ -156,6 +155,25 @@ impl TryFrom<ContactPoint> for SocketAddr {
                 DriverSessionConfigError::invalid_contact_point_addr(addr_str, reason)
             }),
         }
+    }
+}
+
+pub(crate) struct PyDuration(pub(crate) Duration);
+
+impl<'py> FromPyObject<'_, 'py> for PyDuration {
+    type Error = DriverSessionConfigError;
+    fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
+        if let Ok(duration) = obj.extract::<Duration>() {
+            return Ok(PyDuration(duration));
+        }
+
+        if let Ok(secs) = obj.extract::<f64>() {
+            let duration = Duration::try_from_secs_f64(secs)
+                .map_err(|_| DriverSessionConfigError::invalid_duration(obj))?;
+            return Ok(PyDuration(duration));
+        }
+
+        Err(DriverSessionConfigError::invalid_duration(obj))
     }
 }
 

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -30,7 +30,7 @@ impl SessionBuilder {
     }
     fn contact_points<'py>(
         mut slf: PyRefMut<'py, Self>,
-        contact_points: ContactPoints,
+        contact_points: NodeAddrs,
     ) -> PyRefMut<'py, Self> {
         contact_points.add_known_nodes(&mut slf.config);
         slf
@@ -104,64 +104,63 @@ impl SessionBuilder {
     }
 }
 
-pub(crate) enum ContactPoint {
+pub(crate) enum NodeAddr {
     Host(String),
     SocketAddr(SocketAddr),
 }
 
-impl ContactPoint {
+impl NodeAddr {
     fn add_known_node(self, config: &mut SessionConfig) {
         match self {
-            ContactPoint::Host(host) => config.add_known_node(host),
-            ContactPoint::SocketAddr(addr) => config.add_known_node_addr(addr),
+            NodeAddr::Host(host) => config.add_known_node(host),
+            NodeAddr::SocketAddr(addr) => config.add_known_node_addr(addr),
         }
     }
 }
 
-impl ToSocketAddrs for ContactPoint {
+impl ToSocketAddrs for NodeAddr {
     type Iter = std::vec::IntoIter<SocketAddr>;
 
     fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
         match self {
-            ContactPoint::SocketAddr(addr) => Ok(vec![*addr].into_iter()),
-            ContactPoint::Host(host) => host.to_socket_addrs(),
+            NodeAddr::SocketAddr(addr) => Ok(vec![*addr].into_iter()),
+            NodeAddr::Host(host) => host.to_socket_addrs(),
         }
     }
 }
 
-impl<'py> FromPyObject<'_, 'py> for ContactPoint {
+impl<'py> FromPyObject<'_, 'py> for NodeAddr {
     type Error = DriverSessionConfigError;
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(s) = obj.extract::<String>() {
-            return Ok(ContactPoint::Host(s));
+            return Ok(NodeAddr::Host(s));
         }
 
         if let Ok((host_str, port)) = obj.extract::<(&str, u16)>() {
             return if let Ok(ip) = IpAddr::from_str(host_str) {
-                Ok(ContactPoint::SocketAddr(SocketAddr::new(ip, port)))
+                Ok(NodeAddr::SocketAddr(SocketAddr::new(ip, port)))
             } else {
-                Ok(ContactPoint::Host(format!("{}:{}", host_str, port)))
+                Ok(NodeAddr::Host(format!("{}:{}", host_str, port)))
             };
         }
 
         if let Ok((host, port)) = obj.extract::<(IpAddr, u16)>() {
-            return Ok(ContactPoint::SocketAddr(SocketAddr::new(host, port)));
+            return Ok(NodeAddr::SocketAddr(SocketAddr::new(host, port)));
         }
 
-        Err(DriverSessionConfigError::contact_point_type_error(obj))
+        Err(DriverSessionConfigError::address_type_error(obj))
     }
 }
 
-impl TryFrom<ContactPoint> for SocketAddr {
+impl TryFrom<NodeAddr> for SocketAddr {
     type Error = DriverSessionConfigError;
 
-    fn try_from(value: ContactPoint) -> Result<Self, Self::Error> {
+    fn try_from(value: NodeAddr) -> Result<Self, Self::Error> {
         match value {
-            ContactPoint::SocketAddr(addr) => Ok(addr),
-            ContactPoint::Host(addr_str) => SocketAddr::from_str(&addr_str).map_err(|reason| {
-                DriverSessionConfigError::invalid_contact_point_addr(addr_str, reason)
-            }),
+            NodeAddr::SocketAddr(addr) => Ok(addr),
+            NodeAddr::Host(addr_str) => SocketAddr::from_str(&addr_str)
+                .map_err(|reason| DriverSessionConfigError::invalid_node_addr(addr_str, reason)),
         }
     }
 }
@@ -185,66 +184,47 @@ impl<'py> FromPyObject<'_, 'py> for PyDuration {
     }
 }
 
-pub(crate) enum ContactPoints {
-    Single(ContactPoint),
-    Multiple(Vec<ContactPoint>),
+pub(crate) struct NodeAddrs {
+    pub(crate) inner: Vec<NodeAddr>,
 }
 
-impl IntoIterator for ContactPoints {
-    type Item = ContactPoint;
-    type IntoIter = std::vec::IntoIter<ContactPoint>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self {
-            ContactPoints::Single(cp) => vec![cp].into_iter(),
-            ContactPoints::Multiple(cps) => cps.into_iter(),
-        }
-    }
-}
-
-impl ContactPoints {
+impl NodeAddrs {
     fn add_known_nodes(self, config: &mut SessionConfig) {
-        match self {
-            ContactPoints::Single(cp) => cp.add_known_node(config),
-            ContactPoints::Multiple(seq) => {
-                for cp in seq.into_iter() {
-                    cp.add_known_node(config);
-                }
-            }
+        for cp in self.inner.into_iter() {
+            cp.add_known_node(config);
         }
     }
 }
 
-impl<'py> FromPyObject<'_, 'py> for ContactPoints {
+impl<'py> FromPyObject<'_, 'py> for NodeAddrs {
     type Error = DriverSessionConfigError;
 
     fn extract(obj: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-        if let Ok(s) = obj.extract::<ContactPoint>() {
-            return Ok(ContactPoints::Single(s));
+        if let Ok(s) = obj.extract::<NodeAddr>() {
+            return Ok(NodeAddrs { inner: vec![s] });
         }
 
         if let Ok(seq) = obj.cast::<PySequence>() {
             let iter = seq
                 .try_iter()
-                .map_err(DriverSessionConfigError::contact_points_iteration_failed)?;
+                .map_err(DriverSessionConfigError::node_addr_iteration_failed)?;
 
-            let list: Vec<ContactPoint> = iter
+            let list: Vec<NodeAddr> = iter
                 .enumerate()
                 .map(|(index, item_result)| {
-                    let item = item_result.map_err(|e| {
-                        DriverSessionConfigError::contact_points_invalid_item(index, e)
-                    })?;
+                    let item = item_result
+                        .map_err(|e| DriverSessionConfigError::invalid_node_addr_item(index, e))?;
 
-                    item.extract::<ContactPoint>().map_err(|e| {
-                        DriverSessionConfigError::contact_points_invalid_item(index, e.into())
+                    item.extract::<NodeAddr>().map_err(|e| {
+                        DriverSessionConfigError::invalid_node_addr_item(index, e.into())
                     })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            return Ok(ContactPoints::Multiple(list));
+            return Ok(NodeAddrs { inner: list });
         }
 
-        Err(DriverSessionConfigError::contact_point_type_error(obj))
+        Err(DriverSessionConfigError::address_type_error(obj))
     }
 }
 

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -2,15 +2,15 @@ use crate::RUNTIME;
 use crate::errors::{DriverSessionConfigError, DriverSessionConnectionError};
 use crate::execution_profile::ExecutionProfile;
 use crate::policies::{
-    AddressTranslatorInput, InternalAuthenticatorProvider, InternalHostFilter,
-    PyAuthenticatorProvider, PyHostFilter, TimestampGeneratorInput,
+    AddressTranslatorInput, HostFilterInput, InternalAuthenticatorProvider,
+    PyAuthenticatorProvider, TimestampGeneratorInput,
 };
 use crate::session::Session;
 use pyo3::prelude::*;
 use pyo3::types::PySequence;
 use scylla::authentication::PlainTextAuthenticator;
 use scylla::client::session::SessionConfig;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -81,14 +81,11 @@ impl SessionBuilder {
 
         slf
     }
-
     fn host_filter<'py>(
         mut slf: PyRefMut<'py, Self>,
-        host_filter: Py<PyHostFilter>,
+        host_filter: HostFilterInput,
     ) -> PyRefMut<'py, Self> {
-        slf.config.host_filter = Some(Arc::new(InternalHostFilter {
-            py_host_filter: host_filter,
-        }));
+        slf.config.host_filter = Some(host_filter.into_inner());
 
         slf
     }
@@ -117,6 +114,17 @@ impl ContactPoint {
         match self {
             ContactPoint::Host(host) => config.add_known_node(host),
             ContactPoint::SocketAddr(addr) => config.add_known_node_addr(addr),
+        }
+    }
+}
+
+impl ToSocketAddrs for ContactPoint {
+    type Iter = std::vec::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> std::io::Result<Self::Iter> {
+        match self {
+            ContactPoint::SocketAddr(addr) => Ok(vec![*addr].into_iter()),
+            ContactPoint::Host(host) => host.to_socket_addrs(),
         }
     }
 }
@@ -177,9 +185,21 @@ impl<'py> FromPyObject<'_, 'py> for PyDuration {
     }
 }
 
-enum ContactPoints {
+pub(crate) enum ContactPoints {
     Single(ContactPoint),
     Multiple(Vec<ContactPoint>),
+}
+
+impl IntoIterator for ContactPoints {
+    type Item = ContactPoint;
+    type IntoIter = std::vec::IntoIter<ContactPoint>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            ContactPoints::Single(cp) => vec![cp].into_iter(),
+            ContactPoints::Multiple(cps) => cps.into_iter(),
+        }
+    }
 }
 
 impl ContactPoints {

--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -2,9 +2,8 @@ use crate::RUNTIME;
 use crate::errors::{DriverSessionConfigError, DriverSessionConnectionError};
 use crate::execution_profile::ExecutionProfile;
 use crate::policies::{
-    InternalAddressTranslator, InternalAuthenticatorProvider, InternalHostFilter,
-    InternalTimestampGenerator, PyAddressTranslator, PyAuthenticatorProvider, PyHostFilter,
-    PyTimestampGenerator,
+    AddressTranslatorInput, InternalAuthenticatorProvider, InternalHostFilter,
+    InternalTimestampGenerator, PyAuthenticatorProvider, PyHostFilter, PyTimestampGenerator,
 };
 use crate::session::Session;
 use pyo3::prelude::*;
@@ -66,11 +65,9 @@ impl SessionBuilder {
 
     fn address_translator<'py>(
         mut slf: PyRefMut<'py, Self>,
-        translator: Py<PyAddressTranslator>,
+        translator: AddressTranslatorInput,
     ) -> PyRefMut<'py, Self> {
-        slf.config.address_translator = Some(Arc::new(InternalAddressTranslator {
-            python_translator: translator,
-        }));
+        slf.config.address_translator = Some(translator.into_inner());
 
         slf
     }
@@ -111,7 +108,7 @@ impl SessionBuilder {
     }
 }
 
-enum ContactPoint {
+pub(crate) enum ContactPoint {
     Host(String),
     SocketAddr(SocketAddr),
 }
@@ -146,6 +143,19 @@ impl<'py> FromPyObject<'_, 'py> for ContactPoint {
         }
 
         Err(DriverSessionConfigError::contact_point_type_error(obj))
+    }
+}
+
+impl TryFrom<ContactPoint> for SocketAddr {
+    type Error = DriverSessionConfigError;
+
+    fn try_from(value: ContactPoint) -> Result<Self, Self::Error> {
+        match value {
+            ContactPoint::SocketAddr(addr) => Ok(addr),
+            ContactPoint::Host(addr_str) => SocketAddr::from_str(&addr_str).map_err(|reason| {
+                DriverSessionConfigError::invalid_contact_point_addr(addr_str, reason)
+            }),
+        }
     }
 }
 


### PR DESCRIPTION
# Changes 
## Protocol-based approach
HostFilter, AddressTranslator, and TimestampGenerator are now defined as Protocols instead of requiring users to inherit from a concrete base class.

This makes custom implementations simpler and more flexible: users only need to provide objects with the expected methods, without explicitly subclassing driver-provided types.

## Authentication remains class-based
Authenticator and AuthenticatorProvider are intentionally kept as classes.
Authentication flows are more complex than host filtering, address translation, or timestamp generation.  Keeping a class-based API should make these implementations easier to structure and extend.
Built-in authentication providers are intentionally left for a separate PR.
## ContactPoint renamed to NodeAddr
ContactPoint has been renamed to NodeAddr to better reflect that this type represents a node address rather than only an initial contact point.
## New built-in implementations
This PR adds the following built-ins:
### Host filters
- AcceptAllHostFilter
- DcHostFilter
 
It also adds support for list-based host filtering, so users can simply provide a list of allowed hosts without manually implementing a custom host filter.
### Timestamp generators
- SimpleTimestampGenerator
- MonotonicTimestampGenerator
### Address translation
This PR adds built-in support for dictionary-based address translation. Users can provide a mapping from original node addresses to translated addresses directly, without implementing a custom translator class.

Fixes: https://github.com/scylladb-zpp-2025-python-rs-driver/python-rs-driver/issues/69

## Pre-review checklist

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- [x] I added relevant tests for new features and bug fixes.
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- [x] I have provided docstrings for the public items that I want to introduce.
- [ ] I have adjusted the documentation in `./docs/source/`.
- [x] I added appropriate `Fixes:` annotations to PR description.
