### PR TITLE
Advertise driver's name and version to the server

### DIFF
--- a/src/session_builder.rs
+++ b/src/session_builder.rs
@@ -10,10 +10,14 @@ use crate::session::PySession;
 use pyo3::prelude::*;
 use pyo3::types::PySequence;
 use scylla::authentication::PlainTextAuthenticator;
+use scylla::client::SelfIdentity;
 use scylla::client::session::SessionConfig;
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
+
+const DEFAULT_DRIVER_NAME: &str = "ScyllaDB Python RS Driver";
+const DEFAULT_DRIVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[pyclass]
 struct SessionBuilder {
@@ -98,7 +102,11 @@ impl SessionBuilder {
     }
 
     async fn connect(&self) -> Result<PySession, DriverSessionConnectionError> {
-        let config = self.config.clone();
+        let mut config = self.config.clone();
+        config.identity = SelfIdentity::new()
+            .with_custom_driver_name(DEFAULT_DRIVER_NAME)
+            .with_custom_driver_version(DEFAULT_DRIVER_VERSION);
+
         let session_result = RUNTIME
             .spawn(async move { scylla::client::session::Session::connect(config).await })
             .await?;


### PR DESCRIPTION
Before, this driver would advertise itself as "ScyllaDB Rust Driver", with version of the ScyllaDB Rust Driver.
Now, it will advertise itself as "ScyllaDB Python RS Driver", with version taken from Cargo.toml.

## Pre-review checklist

<!--
    Make sure you took care of the issues on the list.
    Put 'x' into those boxes which apply.
    You can also create the PR now and click on all relevant checkboxes.
    See CONTRIBUTING.md for more details.
-->

- [x] I have split my patch into logically separate commits.
- [x] All commit messages clearly explain what they change and why.
- ~~[ ] I added relevant tests for new features and bug fixes.~~
- [x] All commits compile, pass static checks and pass test.
- [x] PR description sums up the changes and reasons why they should be introduced.
- ~~[ ] I have provided docstrings for the public items that I want to introduce.~~
- ~~[ ] I have adjusted the documentation in `./docs/source/`.~~
- ~~[ ] I added appropriate `Fixes:` annotations to PR description.~~
